### PR TITLE
Cargo.toml: Fix URL in package.repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pdf"
 version = "0.6.2"
 authors = ["Erlend Hofstad Langseth <3rlendhl@gmail.com>", "Sebastian Köln <sebk@rynx.org>"]
-repository = "https://github.com/pdf/pdf-rs"
+repository = "https://github.com/pdf-rs/pdf"
 readme = "README.md"
 keywords = ["pdf"]
 license = "MIT"


### PR DESCRIPTION
https://github.com/pdf/pdf-rs doesn't exist  ;)