### PR TITLE
Fix build errors with rustc v1.33.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Erlend Hofstad Langseth <3rlendhl@gmail.com>", "Sebastian Köln <sebk@rynx.org>"]
 repository = "https://github.com/pdf-rs/pdf"
 readme = "README.md"

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,3 +1,7 @@
+// Workaround until 
+// https://github.com/rust-lang-nursery/error-chain/pull/255
+// is implemented:
+#![allow(deprecated)]
 use object::ObjNr;
 error_chain! {
     // The type defined for this error. These are the conventional

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
-#![feature(attr_literals)]
 #![recursion_limit="128"]
 //#![feature(collections_range)]
 //#![feature(slice_get_slice)]
 #![allow(non_camel_case_types)]  /* TODO temporary becaues of pdf_derive */
     #![allow(unused_doc_comments)] // /* TODO temporary because of err.rs */
-#![feature(use_extern_macros)] // because of error-chain experimenting
 #[macro_use]
 extern crate pdf_derive;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //#![feature(collections_range)]
 //#![feature(slice_get_slice)]
 #![allow(non_camel_case_types)]  /* TODO temporary becaues of pdf_derive */
-#![allow(unused_doc_comment)] // /* TODO temporary because of err.rs */
+    #![allow(unused_doc_comments)] // /* TODO temporary because of err.rs */
 #![feature(use_extern_macros)] // because of error-chain experimenting
 #[macro_use]
 extern crate pdf_derive;


### PR DESCRIPTION
This PR fixes build errors with rustc v1.33.0

It introduces a workaround to tackle an issue that originates in error_chain.
It removes feature flags, that are already implemented at this point in time.