### PR TITLE
Use the log crate in lieu of println/eprintln

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ lzw = "0.10.0"
 tuple = "0.4.0"
 glob = "0.2.11"
 chrono = "0.4.0"
+log = "0.4.6"
 
 [lib]
 doctest = false

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -52,7 +52,7 @@ pub trait Backend: Sized {
                 None => None
             }
         };
-        println!("READ XREF AND TABLE");
+        trace!("READ XREF AND TABLE");
         while let Some(prev_xref_offset) = prev_trailer {
             let mut lexer = Lexer::new(self.read(prev_xref_offset as usize..)?);
             let (xref_sections, trailer) = read_xref_and_trailer_at(&mut lexer, NO_RESOLVE)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 extern crate pdf_derive;
 #[macro_use]
 extern crate error_chain;
+#[macro_use]
+extern crate log;
 extern crate num_traits;
 extern crate inflate;
 extern crate itertools;

--- a/src/object/stream.rs
+++ b/src/object/stream.rs
@@ -32,7 +32,7 @@ impl<I: Object> Object for Stream<I> {
 impl<I: Object> Stream<I> {
     pub fn decode(&mut self) -> Result<()> {
         for filter in &self.info.filters {
-            eprintln!("Decode filter: {:?}", filter);
+            trace!("Decode filter: {:?}", filter);
             self.data = decode(&self.data, filter)?;
         }
         self.info.filters.clear();


### PR DESCRIPTION
There are a couple print statements in the library that write to stdout and stderr when opening a file. This PR pulls in the `log` crate and changes those lines to use `trace!()`, so that clients can choose whether and how to get log messages.