### PR TITLE
Make pdf_derive usable from other crates

### DIFF
--- a/pdf/src/crypt.rs
+++ b/pdf/src/crypt.rs
@@ -1,5 +1,6 @@
 /// PDF "cryptography" – This is why you don't write your own crypto.
 
+use crate as pdf;
 use crate::primitive::PdfString;
 use crate::error::{PdfError, Result};
 

--- a/pdf/src/enc.rs
+++ b/pdf/src/enc.rs
@@ -3,6 +3,7 @@ use tuple::*;
 use inflate::inflate_bytes_zlib;
 use std::mem;
 
+use crate as pdf;
 use crate::error::*;
 use crate::object::{Object, Resolve};
 use crate::primitive::{Primitive, Dictionary};

--- a/pdf/src/encoding/mod.rs
+++ b/pdf/src/encoding/mod.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU32;
 use std::io;
 use std::collections::HashMap;
+use crate as pdf;
 use crate::object::{Object, Resolve};
 use crate::primitive::Primitive;
 use crate::error::{Result, PdfError};

--- a/pdf/src/file.rs
+++ b/pdf/src/file.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use crate as pdf;
 use crate::error::*;
 use crate::object::*;
 use crate::primitive::{Primitive, Dictionary, PdfString};

--- a/pdf/src/font.rs
+++ b/pdf/src/font.rs
@@ -1,3 +1,4 @@
+use crate as pdf;
 use crate::object::*;
 use crate::primitive::*;
 use crate::error::*;

--- a/pdf/src/object/stream.rs
+++ b/pdf/src/object/stream.rs
@@ -1,3 +1,4 @@
+use crate as pdf;
 use crate::object::*;
 use crate::primitive::*;
 use crate::error::*;

--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::rc::Rc;
 use std::ops::Deref;
 
+use crate as pdf;
 use crate::object::*;
 use crate::error::*;
 use crate::content::Content;


### PR DESCRIPTION
This PR adjusts the paths used in pdf_derive's macro, so that it can be used from other crates again. Instead of using module paths that start with `crate::`, which won't work in crates other than pdf, this uses paths that start with `pdf::`, and adds `use crate as pdf;` to the files in pdf where it is used.