### PR TITLE
Fix features declaration in Cargo.toml

### DIFF
--- a/pdf/Cargo.toml
+++ b/pdf/Cargo.toml
@@ -13,7 +13,8 @@ Read, alter and write PDF files.
 (Crate that previously resided here moved to pdf-canvas)
 """
 
-features = ["unstable"]
+[features]
+unstable = []
 
 [dependencies.pdf_derive]
 path = "../pdf_derive"


### PR DESCRIPTION
Cargo was warning about this getting ignored. Alternatively it could just be removed too.