### PR TITLE
Add script to download and extract fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Cargo.lock
 **/perf.data.old
 
 !.travis.yml
+
+/fonts

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ tar -xf fonts.tar.bz
 ```
 placing the `fonts` directory in repository directory.
 
-Alternativly you can get them from [this old debian release of the Adobe PDF reader](http://ardownload.adobe.com/pub/adobe/reader/unix/9.x/9.5.5/enu/AdbeRdr9.5.5-1_i386linux_enu.deb) And `AdobePiStd.ttf` can be found on the internet as well:
+Alternativly you can run `./download_fonts.sh` to get them from [this old debian release of the Adobe PDF reader](http://ardownload.adobe.com/pub/adobe/reader/unix/9.x/9.5.5/enu/AdbeRdr9.5.5-1_i386linux_enu.deb). And `AdobePiStd.ttf` can be found on the internet as well:
 
 Over all you will need in the `fonts` directory:
  - `CourierStd.otf`

--- a/download_fonts.sh
+++ b/download_fonts.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+TMPDIR=`mktemp -d`
+if [[ ! "$TMPDIR" || ! -d "$TMPDIR" ]]; then
+    echo "Couldn't create temporary directory"
+    exit 1
+fi
+function cleanup {
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+curl http://ardownload.adobe.com/pub/adobe/reader/unix/9.x/9.5.5/enu/AdbeRdr9.5.5-1_i386linux_enu.deb > "$TMPDIR/AdbeRdr9.5.5-1_i386linux_enu.deb"
+(cd "$TMPDIR" && ar x AdbeRdr9.5.5-1_i386linux_enu.deb data.tar.gz)
+mkdir -p fonts/PFM
+tar xzf "$TMPDIR/data.tar.gz" --directory=fonts --strip-components=6 ./opt/Adobe/Reader9/Resource/Font/{AdobePiStd.otf,CourierStd-BoldOblique.otf,CourierStd-Bold.otf,CourierStd-Oblique.otf,CourierStd.otf,MinionPro-BoldIt.otf,MinionPro-Bold.otf,MinionPro-It.otf,MinionPro-Regular.otf,MyriadPro-BoldIt.otf,MyriadPro-Bold.otf,MyriadPro-It.otf,MyriadPro-Regular.otf,ZX______.PFB,ZY______.PFB,SY______.PFB} ./opt/Adobe/Reader9/Resource/Font/PFM/{zx______.pfm,zy______.pfm,SY______.PFM}


### PR DESCRIPTION
Here's a bash script to simplify downloading and extracting fonts from the Adobe Reader deb file. (follow-up to #50)