### PR TITLE
add an example to print metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "examples/read",
     "examples/text",
     "examples/names",
+    "examples/metadata",
 ]
 default-members = [
     "pdf",

--- a/examples/metadata/Cargo.toml
+++ b/examples/metadata/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "metadata"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+pdf = { path = "../../pdf" }

--- a/examples/metadata/src/main.rs
+++ b/examples/metadata/src/main.rs
@@ -1,0 +1,18 @@
+use std::env::args;
+
+use pdf::error::PdfError;
+use pdf::file::File;
+
+/// extract and print a PDF's metadata
+fn main() -> Result<(), PdfError> {
+    let path = args()
+        .nth(1)
+        .expect("Please provide a file path to the PDF you want to explore.");
+
+    let file = File::<Vec<u8>>::open(&path).unwrap();
+    if let Some(ref info) = file.trailer.info_dict {
+        eprintln!("{:?}", info);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I'm curious if there are other kinds of metadata inside PDFs. I stole
this logic from examples/read/src/main.rs.

Partly address #31.