### PR TITLE
Fix most warnings and clippy

### DIFF
--- a/pdf/src/backend.rs
+++ b/pdf/src/backend.rs
@@ -1,10 +1,10 @@
 use crate::error::*;
 use crate::parser::Lexer;
-use crate::parser::{read_xref_and_trailer_at};
-use crate::xref::{XRefTable};
-use crate::primitive::{Dictionary};
+use crate::parser::read_xref_and_trailer_at;
+use crate::xref::XRefTable;
+use crate::primitive::Dictionary;
 use crate::object::*;
-use std::ops::{Deref};
+use std::ops::Deref;
 
 use std::ops::{
     RangeFull,
@@ -18,6 +18,9 @@ pub trait Backend: Sized {
     fn read<T: IndexRange>(&self, range: T) -> Result<&[u8]>;
     //fn write<T: IndexRange>(&mut self, range: T) -> Result<&mut [u8]>;
     fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Returns the value of startxref (currently only used internally!)
     fn locate_xref_offset(&self) -> Result<usize> {
@@ -33,7 +36,7 @@ pub trait Backend: Sized {
 
     /// Used internally by File, but could also be useful for applications that want to look at the raw PDF objects.
     fn read_xref_table_and_trailer(&self) -> Result<(XRefTable, Dictionary)> {
-        let mut xref_offset = t!(self.locate_xref_offset());
+        let xref_offset = t!(self.locate_xref_offset());
         let mut lexer = Lexer::new(t!(self.read(xref_offset..)));
         
         let (xref_sections, trailer) = t!(read_xref_and_trailer_at(&mut lexer, &NoResolve));

--- a/pdf/src/content.rs
+++ b/pdf/src/content.rs
@@ -1,5 +1,4 @@
 /// PDF content streams.
-use std;
 use std::fmt::{Display, Formatter};
 use std::mem::replace;
 use std::io;
@@ -20,8 +19,8 @@ pub struct Operation {
 impl Operation {
     pub fn new(operator: String, operands: Vec<Primitive>) -> Operation {
         Operation{
-            operator: operator,
-            operands: operands,
+            operator,
+            operands,
         }
     }
 }

--- a/pdf/src/crypt.rs
+++ b/pdf/src/crypt.rs
@@ -24,7 +24,7 @@ impl Clone for Rc4 { fn clone(&self) -> Rc4 { *self } }
 
 impl Rc4 {
     pub fn new(key: &[u8]) -> Rc4 {
-        assert!(key.len() >= 1 && key.len() <= 256);
+        assert!(!key.is_empty() && key.len() <= 256);
         let mut rc4 = Rc4 { i: 0, j: 0, state: [0; 256] };
         for (i, x) in rc4.state.iter_mut().enumerate() {
             *x = i as u8;
@@ -40,8 +40,7 @@ impl Rc4 {
         self.i = self.i.wrapping_add(1);
         self.j = self.j.wrapping_add(self.state[self.i as usize]);
         self.state.swap(self.i as usize, self.j as usize);
-        let k = self.state[(self.state[self.i as usize].wrapping_add(self.state[self.j as usize])) as usize];
-        k
+        self.state[(self.state[self.i as usize].wrapping_add(self.state[self.j as usize])) as usize]
     }
     pub fn encrypt(key: &[u8], data: &mut [u8]) {
         let mut rc4 = Rc4::new(key);
@@ -223,7 +222,7 @@ impl Decoder {
         data
     }
     pub fn check_password(&self, dict: &CryptDict, id: &[u8]) -> bool {
-        self.compute_u(id) == &dict.u.as_bytes()[.. 16]
+        self.compute_u(id) == dict.u.as_bytes()[.. 16]
     }
     pub fn decrypt(&self, id: u64, gen: u16, data: &mut [u8]) {
         // Algorithm 1

--- a/pdf/src/encoding.rs
+++ b/pdf/src/encoding.rs
@@ -40,7 +40,7 @@ impl Object for Encoding {
                 let mut gid = 0;
                 let mut differences = HashMap::new();
                 if let Some(p) = dict.remove("Differences") {
-                    for part in p.to_array(resolve)? {
+                    for part in p.into_array(resolve)? {
                         match part {
                             Primitive::Integer(code) => {
                                 gid = code as u32;

--- a/pdf/src/error.rs
+++ b/pdf/src/error.rs
@@ -1,8 +1,6 @@
 use crate::object::ObjNr;
 use std::io;
 use std::error::Error;
-use std::borrow::Cow;
-use std::ops::Range;
 
 #[derive(Debug, Snafu)]
 pub enum PdfError {
@@ -221,7 +219,7 @@ macro_rules! unimplemented {
 }
 
 #[cfg(not(feature = "dump"))]
-pub fn dump_data(data: &[u8]) {}
+pub fn dump_data(_data: &[u8]) {}
 
 #[cfg(feature = "dump")]
 pub fn dump_data(data: &[u8]) {

--- a/pdf/src/object/function.rs
+++ b/pdf/src/object/function.rs
@@ -49,7 +49,7 @@ impl Function {
     }
 }
 impl Object for Function {
-    fn serialize<W: io::Write>(&self, out: &mut W) -> Result<()> {
+    fn serialize<W: io::Write>(&self, _out: &mut W) -> Result<()> {
         unimplemented!()
     }
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {

--- a/pdf/src/object/stream.rs
+++ b/pdf/src/object/stream.rs
@@ -53,8 +53,8 @@ impl<I: Object + fmt::Debug> Stream<I> {
 
     /// If this is contains DCT encoded data, return the compressed data as is
     pub fn as_jpeg(&self) -> Option<&[u8]> {
-        match self.info.filters.as_slice() {
-            &[StreamFilter::DCTDecode(_)] => Some(self.raw_data.as_slice()),
+        match *self.info.filters.as_slice() {
+            [StreamFilter::DCTDecode(_)] => Some(self.raw_data.as_slice()),
             _ => None
         }
     }
@@ -195,10 +195,10 @@ impl<T: Object> Object for StreamInfo<T> {
         Ok(StreamInfo {
             // General
             filters: new_filters,
-            file: file,
+            file,
             file_filters: new_file_filters,
             // Special
-            info: T::from_primitive(Primitive::Dictionary (dict.clone()), resolve)?,
+            info: T::from_primitive(Primitive::Dictionary (dict), resolve)?,
         })
     }
 }
@@ -249,7 +249,7 @@ impl Object for ObjectStream {
         }
 
         Ok(ObjectStream {
-            offsets: offsets,
+            offsets,
             id: 0, // TODO
             inner: stream
         })
@@ -259,7 +259,7 @@ impl Object for ObjectStream {
 impl ObjectStream {
     pub fn get_object_slice(&self, index: usize) -> Result<&[u8]> {
         if index >= self.offsets.len() {
-            err!(PdfError::ObjStmOutOfBounds {index: index, max: self.offsets.len()});
+            err!(PdfError::ObjStmOutOfBounds {index, max: self.offsets.len()});
         }
         let start = self.inner.info.first as usize + self.offsets[index];
         let data = self.inner.data()?;

--- a/pdf/src/parser/lexer/mod.rs
+++ b/pdf/src/parser/lexer/mod.rs
@@ -1,7 +1,6 @@
 /// Lexing an input file, in the sense of breaking it up into substrings based on delimiters and
 /// whitespace.
 
-use std;
 use std::str::FromStr;
 use std::ops::{Range, Deref};
 use std::io::SeekFrom;
@@ -53,10 +52,7 @@ fn test_boundary() {
 
 #[inline]
 fn is_whitespace(b: u8) -> bool {
-    match b {
-        b' ' | b'\r' | b'\n' | b'\t' => true,
-        _ => false
-    }
+    matches!(b, b' ' | b'\r' | b'\n' | b'\t')
 }
 #[inline]
 fn not<T>(f: impl Fn(T) -> bool) -> impl Fn(T) -> bool {
@@ -66,11 +62,12 @@ impl<'a> Lexer<'a> {
     pub fn new(buf: &'a [u8]) -> Lexer<'a> {
         Lexer {
             pos: 0,
-            buf: buf,
+            buf,
         }
     }
 
     /// Returns next lexeme. Lexer moves to the next byte after the lexeme. (needs to be tested)
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Result<Substr<'a>> {
         let (lexeme, pos) = self.next_word()?;
         self.pos = pos;
@@ -130,7 +127,7 @@ impl<'a> Lexer<'a> {
             Err(PdfError::UnexpectedLexeme {
                 pos: self.pos,
                 lexeme: word.to_string(),
-                expected: expected
+                expected
             })
         }
     }
@@ -380,16 +377,10 @@ impl<'a> Substr<'a> {
         std::str::from_utf8(self.slice)?.parse::<T>().map_err(|e| PdfError::Parse { source: e.into() })
     }
     pub fn is_integer(&self) -> bool {
-        match self.to::<i32>() {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        self.to::<i32>().is_ok()
     }
     pub fn is_real_number(&self) -> bool {
-        match self.to::<f32>() {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        self.to::<f32>().is_ok()   
     }
 
     pub fn as_slice(&self) -> &'a [u8] {

--- a/pdf/src/parser/lexer/str.rs
+++ b/pdf/src/parser/lexer/str.rs
@@ -33,7 +33,7 @@ impl<'a> StringLexer<'a> {
         StringLexer {
             pos: 0,
             nested: 0,
-            buf: buf,
+            buf,
         }
     }
     pub fn iter<'b>(&'b mut self) -> StringLexerIter<'a, 'b> {

--- a/pdf/src/parser/parse_object.rs
+++ b/pdf/src/parser/parse_object.rs
@@ -18,7 +18,7 @@ pub fn parse_indirect_object(lexer: &mut Lexer, r: &impl Resolve, decoder: Optio
     lexer.next_expect("obj")?;
 
     let ctx = Context {
-        decoder: decoder,
+        decoder,
         obj_nr,
         gen_nr
     };
@@ -34,7 +34,7 @@ pub fn parse_indirect_stream(lexer: &mut Lexer, r: &impl Resolve, decoder: Optio
     lexer.next_expect("obj")?;
 
     let ctx = Context {
-        decoder: decoder,
+        decoder,
         obj_nr,
         gen_nr
     };

--- a/pdf/src/parser/parse_xref.rs
+++ b/pdf/src/parser/parse_xref.rs
@@ -31,7 +31,7 @@ fn parse_xref_section_from_stream(first_id: i32, num_entries: i32, width: &[i32]
     }
     Ok(XRefSection {
         first_id: first_id as u32,
-        entries: entries,
+        entries,
     })
 }
 /// Helper to read an integer with a certain amount of bits `width` from stream.
@@ -100,7 +100,7 @@ pub fn parse_xref_table_and_trailer(lexer: &mut Lexer, resolve: &impl Resolve) -
     // Read trailer
     t!(lexer.next_expect("trailer"));
     let trailer = t!(parse_with_lexer(lexer, resolve));
-    let trailer = t!(trailer.to_dictionary(resolve));
+    let trailer = t!(trailer.into_dictionary(resolve));
  
     Ok((sections, trailer))
 }

--- a/pdf/src/xref.rs
+++ b/pdf/src/xref.rs
@@ -1,4 +1,3 @@
-use std;
 use std::fmt::{Debug, Formatter};
 use crate::error::*;
 use crate::object::*;
@@ -56,7 +55,7 @@ impl XRefTable {
         let mut entries = Vec::new();
         entries.resize(num_objects as usize, XRef::Invalid);
         XRefTable {
-            entries: entries,
+            entries,
         }
     }
 
@@ -70,7 +69,7 @@ impl XRefTable {
     pub fn get(&self, id: ObjNr) -> Result<XRef> {
         match self.entries.get(id as usize) {
             Some(&entry) => Ok(entry),
-            None => Err(PdfError::UnspecifiedXRefEntry {id: id}),
+            None => Err(PdfError::UnspecifiedXRefEntry {id}),
         }
     }
 
@@ -141,15 +140,15 @@ pub struct XRefSection {
 impl XRefSection {
     pub fn new(first_id: u32) -> XRefSection {
         XRefSection {
-            first_id: first_id,
+            first_id,
             entries: Vec::new(),
         }
     }
     pub fn add_free_entry(&mut self, next_obj_nr: ObjNr, gen_nr: GenNr) {
-        self.entries.push(XRef::Free{next_obj_nr: next_obj_nr, gen_nr: gen_nr});
+        self.entries.push(XRef::Free{next_obj_nr, gen_nr});
     }
     pub fn add_inuse_entry(&mut self, pos: usize, gen_nr: u16) {
-        self.entries.push(XRef::Raw{pos: pos, gen_nr: gen_nr});
+        self.entries.push(XRef::Raw{pos, gen_nr});
     }
     pub fn entries(&self) -> impl Iterator<Item=(usize, &XRef)> {
         self.entries.iter().enumerate().map(move |(i, e)| (i + self.first_id as usize, e))


### PR DESCRIPTION
Contains one breaking change, namely renaming `Primitive::to_*` function to `Primitive::into_*` because they take `self`.

Next I'm not sure about these
```
warning: unused variable: `ctx`
   --> pdf/src/parser/mod.rs:196:65
    |
196 | fn parse_stream_with_lexer(lexer: &mut Lexer, r: &impl Resolve, ctx: Option<&Context>) -> Result<PdfStream> {
    |                                                                 ^^^ help: if this is intentional, prefix it with an underscore: `_ctx`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `params`
   --> pdf/src/enc.rs:196:28
    |
196 | fn dct_decode(data: &[u8], params: &DCTDecodeParams) -> Result<Vec<u8>> {
    |                            ^^^^^^ help: if this is intentional, prefix it with an underscore: `_params`

```
Whether the arguments have yet to be used or should be removed.

And 3 of the clippy warnings are weird or incorrect, will report it at clippy.