### PR TITLE
Make xref offsets relative to file header

### DIFF
--- a/files/offset.pdf
+++ b/files/offset.pdf
@@ -1,0 +1,75 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+%PDF-1.7
+%µí®û
+3 0 obj
+<< /Length 4 0 R >>
+stream
+/DeviceRGB cs /DeviceRGB CS
+0 0 0.972549 SC
+21.68 194 136.64 26 re
+10 10 m 20 20 l S
+BT
+/F0 24 Tf
+25.68 200 Td
+(Hello World!) Tj
+ET
+endstream
+endobj
+4 0 obj
+132
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Times-Roman /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Type /Page
+   /Parent 2 0 R
+   /Resources << /Font << /F0 5 0 R >> >>
+   /MediaBox [ 0 0 180 240 ]
+   /Contents 3 0 R
+>>
+endobj
+2 0 obj
+<< /Type /Pages
+   /Count 1
+   /Kids [ 6 0 R ]
+>>
+endobj
+1 0 obj
+<< /Type /Catalog
+   /Pages 2 0 R
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000522 00000 n 
+0000000457 00000 n 
+0000000015 00000 n 
+0000000199 00000 n 
+0000000218 00000 n 
+0000000317 00000 n 
+trailer
+<< /Size 7
+   /Root 1 0 R
+>>
+startxref
+574
+%%EOF

--- a/pdf/src/backend.rs
+++ b/pdf/src/backend.rs
@@ -22,6 +22,20 @@ pub trait Backend: Sized {
         self.len() == 0
     }
 
+    /// Returns the offset of the beginning of the file, i.e., where the `%PDF-1.5` header is.
+    /// (currently only used internally!)
+    fn locate_start_offset(&self) -> Result<usize> {
+        // Read from the beginning of the file, and look for the header.
+        // Implementation note 13 in version 1.7 of the PDF reference says that Acrobat viewers
+        // expect the header to be within the first 1KB of the file, so we do the same here.
+        const HEADER: &[u8] = b"%PDF-";
+        let buf = t!(self.read(..std::cmp::min(1024, self.len())));
+        buf
+            .windows(HEADER.len())
+            .position(|window| window == HEADER)
+            .ok_or_else(|| PdfError::Other{ msg: "file header is missing".to_string() })
+    }
+
     /// Returns the value of startxref (currently only used internally!)
     fn locate_xref_offset(&self) -> Result<usize> {
         // locate the xref offset at the end of the file
@@ -36,8 +50,9 @@ pub trait Backend: Sized {
 
     /// Used internally by File, but could also be useful for applications that want to look at the raw PDF objects.
     fn read_xref_table_and_trailer(&self) -> Result<(XRefTable, Dictionary)> {
+        let start_offset = t!(self.locate_start_offset());
         let xref_offset = t!(self.locate_xref_offset());
-        let mut lexer = Lexer::new(t!(self.read(xref_offset..)));
+        let mut lexer = Lexer::new(t!(self.read(start_offset + xref_offset..)));
         
         let (xref_sections, trailer) = t!(read_xref_and_trailer_at(&mut lexer, &NoResolve));
         
@@ -58,7 +73,7 @@ pub trait Backend: Sized {
         };
         trace!("READ XREF AND TABLE");
         while let Some(prev_xref_offset) = prev_trailer {
-            let mut lexer = Lexer::new(t!(self.read(prev_xref_offset as usize..)));
+            let mut lexer = Lexer::new(t!(self.read(start_offset + prev_xref_offset as usize..)));
             let (xref_sections, trailer) = t!(read_xref_and_trailer_at(&mut lexer, &NoResolve));
             
             for section in xref_sections {

--- a/pdf/src/backend.rs
+++ b/pdf/src/backend.rs
@@ -49,8 +49,7 @@ pub trait Backend: Sized {
     }
 
     /// Used internally by File, but could also be useful for applications that want to look at the raw PDF objects.
-    fn read_xref_table_and_trailer(&self) -> Result<(XRefTable, Dictionary)> {
-        let start_offset = t!(self.locate_start_offset());
+    fn read_xref_table_and_trailer(&self, start_offset: usize) -> Result<(XRefTable, Dictionary)> {
         let xref_offset = t!(self.locate_xref_offset());
         let mut lexer = Lexer::new(t!(self.read(start_offset + xref_offset..)));
         

--- a/pdf/src/file.rs
+++ b/pdf/src/file.rs
@@ -63,7 +63,12 @@ impl<B: Backend> Resolve for Storage<B> {
             Some(ref p) => Ok((*p).clone()),
             None => match t!(self.refs.get(r.id)) {
                 XRef::Raw {pos, ..} => {
-                    let mut lexer = Lexer::new(t!(self.backend.read(pos ..)));
+                    // TODO: This will be evaluated repeatedly. It should be stored and reused,
+                    // but there isn't a good place to store this offset yet without breaking the
+                    // public API.
+                    let start_offset = t!(self.backend.locate_start_offset());
+
+                    let mut lexer = Lexer::new(t!(self.backend.read(start_offset + pos ..)));
                     let p = t!(parse_indirect_object(&mut lexer, self, self.decoder.as_ref())).1;
                     Ok(p)
                 }

--- a/pdf/src/file.rs
+++ b/pdf/src/file.rs
@@ -36,24 +36,28 @@ impl<'a, T> Into<Ref<T>> for &'a PromisedRef<T> {
 pub struct Storage<B: Backend> {
     // objects identical to those in the backend
     cache: RefCell<HashMap<PlainRef, Any>>,
-    
+
     // objects that differ from the backend
     changes:    HashMap<ObjNr, Primitive>,
-    
+
     refs:       XRefTable,
-    
+
     decoder:    Option<Decoder>,
-    
-    backend: B
+
+    backend: B,
+
+    /// Position of the PDF header in the file.
+    start_offset: usize,
 }
 impl<B: Backend> Storage<B> {
-    pub fn new(backend: B, refs: XRefTable) -> Storage<B> {
+    pub fn new(backend: B, refs: XRefTable, start_offset: usize) -> Storage<B> {
         Storage {
             backend,
             refs,
+            start_offset,
             cache: RefCell::new(HashMap::new()),
             changes: HashMap::new(),
-            decoder: None
+            decoder: None,
         }
     }
 }
@@ -63,12 +67,7 @@ impl<B: Backend> Resolve for Storage<B> {
             Some(ref p) => Ok((*p).clone()),
             None => match t!(self.refs.get(r.id)) {
                 XRef::Raw {pos, ..} => {
-                    // TODO: This will be evaluated repeatedly. It should be stored and reused,
-                    // but there isn't a good place to store this offset yet without breaking the
-                    // public API.
-                    let start_offset = t!(self.backend.locate_start_offset());
-
-                    let mut lexer = Lexer::new(t!(self.backend.read(start_offset + pos ..)));
+                    let mut lexer = Lexer::new(t!(self.backend.read(self.start_offset + pos ..)));
                     let p = t!(parse_indirect_object(&mut lexer, self, self.decoder.as_ref())).1;
                     Ok(p)
                 }
@@ -123,8 +122,9 @@ impl<B: Backend> File<B> {
         Self::load_data(backend).map_err(|e| dbg!(e))
     }
     fn load_data(backend: B) -> Result<Self> {
-        let (refs, trailer) = t!(backend.read_xref_table_and_trailer());
-        let mut storage = Storage::new(backend, refs);
+        let start_offset = t!(backend.locate_start_offset());
+        let (refs, trailer) = t!(backend.read_xref_table_and_trailer(start_offset));
+        let mut storage = Storage::new(backend, refs, start_offset);
 
         if let Some(crypt) = trailer.get("Encrypt") {
             let key = trailer.get("ID").ok_or(

--- a/pdf/src/repair.rs
+++ b/pdf/src/repair.rs
@@ -1,6 +1,7 @@
 
 fn build_xref_table() {
     warn!("can't read xref table: {:?}", e);
+    let start_offset = t!(backend.locate_start_offset());
     let mut lexer = Lexer::new(t!(backend.read(..)));
     let mut objects = Vec::new();
 
@@ -27,7 +28,7 @@ fn build_xref_table() {
             continue;
         }
         xref.push(XRef::Raw {
-            pos: offset,
+            pos: offset - start_offset,
             gen_nr
         });
         last_id = obj_nr;


### PR DESCRIPTION
This PR fixes parsing PDF files where the header is not at offset 0 in the file. In such cases, the offsets in the trailer and xref tables should be interpreted as offsets from the header, and not offsets from the beginning of the underlying file. See mozilla/pdf.js#6194 for a similar issue in pdf.js. I found a file exhibiting this behavior in the wild at https://iaspub.epa.gov/otaqpub/display_file.jsp?docid=50126&flag=1.

There is one TODO outstanding in this PR, so I'll mark it as a draft. Currently, the code searches the beginning of the file for the header's position in multiple places, but I'd like to find a way to compute this once and reuse it. The header offset is needed in both `Backend::read_xref_table_and_trailer(&self)` and `<Storage<B: Backend> as Resolve>::resolve(&self, r: PlainRef)`.

I think the simplest way to do this would be to compute the header position inside `File<B: Backend>::load_data(backend: B)`, and pass it from there into both `read_xref_table_and_trailer()` and `Storage::new`, storing it inside `Storage` for later use. However, this will require breaking changes to the API, as both `Backend::read_xref_table_and_trailer` and `Storage::new` are both publicly visible. Does this API change sound good?