### PR TITLE
Make PdfError Send and Sync

### DIFF
--- a/pdf/src/error.rs
+++ b/pdf/src/error.rs
@@ -7,12 +7,12 @@ pub enum PdfError {
     // Syntax / parsing
     #[snafu(display("Unexpected end of file"))]
     EOF,
-    
+
     #[snafu(display("Error parsing from string: {}", source))]
-    Parse { source: Box<dyn Error> },
-    
+    Parse { source: Box<dyn Error + Send + Sync> },
+
     #[snafu(display("Invalid encoding: {}", source))]
-    Encoding { source: Box<dyn Error> },
+    Encoding { source: Box<dyn Error + Send + Sync> },
 
     #[snafu(display("Out of bounds: index {}, but len is {}", index, len))]
     Bounds { index: usize, len: usize },
@@ -233,5 +233,21 @@ pub fn dump_data(data: &[u8]) {
         info!("data written to {:?}", path);
     } else {
         info!("set PDF_OUT to an existing directory to dump stream data");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PdfError;
+
+    fn assert_send<T: Send>() {}
+
+    fn assert_sync<T: Sync>() {}
+
+    #[test]
+    fn error_is_send_and_sync() {
+        // note that these checks happens at compile time, not when the test is run
+        assert_send::<PdfError>();
+        assert_sync::<PdfError>();
     }
 }

--- a/pdf/src/parser/lexer/mod.rs
+++ b/pdf/src/parser/lexer/mod.rs
@@ -200,7 +200,7 @@ impl<'a> Lexer<'a> {
 
     #[inline]
     pub fn next_as<T>(&mut self) -> Result<T>
-        where T: FromStr, T::Err: std::error::Error + 'static
+        where T: FromStr, T::Err: std::error::Error + Send + Sync + 'static
     {
         self.next().and_then(|word| word.to::<T>())
     }
@@ -372,7 +372,7 @@ impl<'a> Substr<'a> {
         self.slice.to_vec()
     }
     pub fn to<T>(&self) -> Result<T>
-        where T: FromStr, T::Err: std::error::Error + 'static
+        where T: FromStr, T::Err: std::error::Error + Send + Sync + 'static
     {
         std::str::from_utf8(self.slice)?.parse::<T>().map_err(|e| PdfError::Parse { source: e.into() })
     }


### PR DESCRIPTION
This PR makes the PdfError type both Send and Sync, by adding trait bounds to the trait objects it contains, and generic types in a couple functions that produce them. I also added a compile-time assertion for this to catch any future regressions.