### PR TITLE
Gracefully handle too-short strings in AESV2/AESV3

### DIFF
--- a/pdf/src/crypt.rs
+++ b/pdf/src/crypt.rs
@@ -442,7 +442,7 @@ impl Decoder {
             return Ok(data);
         }
 
-        if data.len() == 0 {
+        if data.is_empty() {
             return Ok(data);
         }
 

--- a/pdf/src/crypt.rs
+++ b/pdf/src/crypt.rs
@@ -442,6 +442,10 @@ impl Decoder {
             return Ok(data);
         }
 
+        if data.len() == 0 {
+            return Ok(data);
+        }
+
         // Algorithm 1
         // a) we have those already
 
@@ -477,6 +481,9 @@ impl Decoder {
                 // d)
                 type Aes128Cbc = Cbc<Aes128, Pkcs7>;
                 let key = &key[..(n + 5).min(16)];
+                if data.len() < 16 {
+                    return Err(PdfError::DecryptionFailure);
+                }
                 let (iv, ciphertext) = data.split_at_mut(16);
                 let cipher =
                     t!(Aes128Cbc::new_var(key, iv).map_err(|_| PdfError::DecryptionFailure));
@@ -486,6 +493,9 @@ impl Decoder {
             }
             CryptMethod::AESV3 => {
                 type Aes256Cbc = Cbc<Aes256, Pkcs7>;
+                if data.len() < 16 {
+                    return Err(PdfError::DecryptionFailure);
+                }
                 let (iv, ciphertext) = data.split_at_mut(16);
                 let cipher =
                     t!(Aes256Cbc::new_var(self.key(), iv).map_err(|_| PdfError::DecryptionFailure));


### PR DESCRIPTION
Decrypt the empty string to itself, and return an error rather than panicking when there is not enough data for the IV.

I ran into this in the wild on http://cdn01.foxitsoftware.com/pub/foxit/addonservice/certs/phantom/cer.pdf (password: phantomkey) which uses AESV3. Since the specification of AESV3 hasn't been released, it's impossible to say if empty strings should in fact be decrypted to empty strings, or if this file is improperly constructed, but I figure it's safe enough to just do so.