### PR TITLE
Fix syn 1.0.58 breaking compilation of pdf_derive

### DIFF
--- a/pdf_derive/Cargo.toml
+++ b/pdf_derive/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 syn = { version = "1", features = ["full"] }
+proc-macro2 = "1.0.24"
 quote = "1"
 
 [lib]

--- a/pdf_derive/src/lib.rs
+++ b/pdf_derive/src/lib.rs
@@ -95,8 +95,9 @@ extern crate syn;
 extern crate quote;
 
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use syn::*;
-type SynStream = syn::export::TokenStream2;
+type SynStream = TokenStream2;
 
 // Debugging:
 /*


### PR DESCRIPTION
As described in dtolnay/syn@957840e, using syn::export was always discouraged and has now become a breaking change.
This patched was heavily inspired by nushell/nushell#2867.

Happy Hacking! :keyboard: 