### PR TITLE
RFC: Don't fail if data can't be decrypted

### DIFF
--- a/pdf/src/parser/mod.rs
+++ b/pdf/src/parser/mod.rs
@@ -77,7 +77,13 @@ fn parse_stream_object(dict: Dictionary, lexer: &mut Lexer, r: &impl Resolve, ct
 
     // decrypt it
     if let Some(ctx) = ctx {
-        data = t!(ctx.decrypt(&mut data)).to_vec();
+        data = match ctx.decrypt(&mut data) {
+            Ok(data) => data.to_vec(),
+            Err(err) => {
+                log::error!("Could not decrypt data: {:?}", err);
+                Vec::new()
+            },
+        };
     }
 
     Ok(PdfStream {


### PR DESCRIPTION
Log an error instead and return an empty vec as data in parse_stream_object()

I'm not sure what data is actually used for, but in my case this allowed me to access the metadata of the pdf 
for an indexer I am working on.

PDF that fails with a DecryptionFailure:
https://www.etsi.org/deliver/etsi_ts/123100_123199/123167/11.10.00_60/ts_123167v111000p.pdf

Similar one (contentwise, creator, ..) that doesn't:
https://www.etsi.org/deliver/etsi_ts/123100_123199/123167/11.11.00_60/ts_123167v111100p.pdf

Those PDFs are still readable with a pdf viewer, however pdfinfo reports
```Encrypted:      yes (print:yes copy:yes change:no addNotes:no algorithm:AES)```
vs
```Encrypted:      no```