### PR TITLE
Fix key for line join style

### DIFF
--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -357,7 +357,7 @@ pub struct GraphicsStateParameters {
     #[pdf(key="LC")]
     pub line_cap: Option<LineCap>,
     
-    #[pdf(key="LC")]
+    #[pdf(key="LJ")]
     pub line_join: Option<LineJoin>,
     
     #[pdf(key="ML")]


### PR DESCRIPTION
Small typo I noticed, `"LC" => "LJ"`