### PR TITLE
Replace lzw with weezl

### DIFF
--- a/pdf/Cargo.toml
+++ b/pdf/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.4.2"
 itertools = "0.10.0"
 ordermap = "0.4.2"
 memmap = { version = "0.7.0", optional = true }
-lzw = "0.10.0"
+weezl = "0.1.4"
 glob = "0.3.0"
 chrono = "0.4.19"
 once_cell = "1.5.2"


### PR DESCRIPTION
This fixes an advisory warning since lzw is unmaintained for quite some
time now. The new implementation is also quite a lot faster, mostly for
the (currently unused) encoding. See also: https://github.com/J-F-Liu/lopdf/pull/140