### PR TITLE
Support meta data of Form XObject

### DIFF
--- a/files/formxobject.pdf
+++ b/files/formxobject.pdf
@@ -1,0 +1,70 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog
+   /Pages 2 0 R
+>>
+endobj
+2 0 obj
+<< /Kids [3 0 R]
+   /Type /Pages
+   /Count 1
+>>
+endobj
+3 0 obj
+<< /Contents 4 0 R
+   /Type /Page
+   /Resources << /XObject << /Im0 5 0 R >> >>
+   /Parent 2 0 R
+   /MediaBox [0 0 180 240]
+>>
+endobj
+4 0 obj
+<< /Length 93 >>
+stream
+/DeviceRGB cs /DeviceRGB CS
+0 0 0.972549 SC
+21.68 194 136.64 26 re
+10 10 m 20 20 l S
+/Im0 Do
+endstream
+endobj
+5 0 obj
+<< /Subtype /Form
+   /Type /XObject
+   /FormType 1
+   /Resources << /Font << /F0 6 0 R >> >>
+   /BBox [0 0 180 240]
+   /Length 47
+>>
+stream
+BT
+/F0 24 Tf
+25.68 200 Td
+(Hello World!) Tj
+ET
+endstream
+endobj
+6 0 obj
+<< /Subtype /Type1
+   /Type /Font
+   /BaseFont /Times-Roman
+   /Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000067 00000 n 
+0000000130 00000 n 
+0000000272 00000 n 
+0000000414 00000 n 
+0000000626 00000 n 
+trailer
+<< /Root 1 0 R
+   /Size 7
+>>
+startxref
+734
+%%EOF

--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -429,7 +429,7 @@ pub type PostScriptXObject = Stream<PostScriptDict>;
 /// A variant of XObject
 pub type ImageXObject = Stream<ImageDict>;
 /// A variant of XObject
-pub type FormXObject = Content;
+pub type FormXObject = Stream<FormDict>;
 
 #[derive(Object, Debug)]
 #[pdf(Type="XObject", Subtype="PS")]
@@ -510,7 +510,47 @@ pub enum RenderingIntent {
 #[derive(Object, Debug)]
 #[pdf(Type="XObject?", Subtype="Form")]
 pub struct FormDict {
-    // TODO
+    #[pdf(key="FormType", default="1")]
+    pub form_type: i32,
+
+    #[pdf(key="Name")]
+    pub name: Option<String>,
+
+    #[pdf(key="LastModified")]
+    pub last_modified: Option<String>,
+
+    #[pdf(key="BBox")]
+    pub bbox: Rect,
+
+    #[pdf(key="Matrix")]
+    pub matrix: Option<Primitive>,
+
+    #[pdf(key="Resources")]
+    pub resources: Option<MaybeRef<Resources>>,
+
+    #[pdf(key="Group")]
+    pub group: Option<Dictionary>,
+
+    #[pdf(key="Ref")]
+    pub reference: Option<Dictionary>,
+
+    #[pdf(key="Metadata")]
+    pub metadata: Option<Ref<Stream>>,
+
+    #[pdf(key="PieceInfo")]
+    pub piece_info: Option<Dictionary>,
+
+    #[pdf(key="StructParent")]
+    pub struct_parent: Option<i32>,
+
+    #[pdf(key="StructParents")]
+    pub struct_parents: Option<i32>,
+
+    #[pdf(key="OPI")]
+    pub opi: Option<Dictionary>,
+
+    #[pdf(other)]
+    pub other: Dictionary,
 }
 
 


### PR DESCRIPTION
This branch parses dictionaries of Form XObjects.

Currently, such the following FormXObjects are stored in `Content`.
This branch adds some attributes to `FormDict` to hold resources and other information.
```
5 0 obj
<< /Subtype /Form
   /Type /XObject
   /FormType 1
   /Resources << /Font << /F0 6 0 R >> >>
   /BBox [0 0 180 240]
   /Length 47
>>
stream
BT
/F0 24 Tf
25.68 200 Td
(Hello World!) Tj
ET
endstream
endobj
```

This branch uses `Stream<FormDict>`, so stream data can be retrieved using `data()` function.
`Stream<I>` is useful for retrieving raw binary data such as image data.
But I couldn't find good solutions for converting it to `Content`. Is there good idea?