### PR TITLE
Handle /Contents being an indirect array

### DIFF
--- a/pdf/src/content.rs
+++ b/pdf/src/content.rs
@@ -465,6 +465,7 @@ impl Object for Content {
                     parts.push(part);
                 }
             }
+            Primitive::Reference(r) => return Self::from_primitive(t!(resolve.resolve(r)), resolve),
             p => {
                 let part = t!(ContentStream::from_primitive(p, resolve));
                 let data = t!(part.data());


### PR DESCRIPTION
This is a partial fix for #90, see [the discussion there](https://github.com/pdf-rs/pdf/issues/90#issuecomment-853527020). `<ContentStream as Object>::from_primitive` needs a small tweak to handle indirect objects that are arrays of streams.