### PR TITLE
Add fuzzing harness

### DIFF
--- a/pdf/fuzz/.gitignore
+++ b/pdf/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/pdf/fuzz/Cargo.toml
+++ b/pdf/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "pdf-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.pdf]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parse"
+path = "fuzz_targets/parse.rs"
+test = false
+doc = false

--- a/pdf/fuzz/fuzz_targets/parse.rs
+++ b/pdf/fuzz/fuzz_targets/parse.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(p) = pdf::file::File::from_data(data) {
+        for _ in p.pages() {}
+    }
+});


### PR DESCRIPTION
This uses https://github.com/rust-fuzz/cargo-fuzz in order to generate random (likely invalid) PDFs, and then tries to parse them.

It's a good way to find invalid inputs that cause panics. I'll make pull requests with test cases for the issues that I find using it, but you should also probably set it up to find bugs.