### PR TITLE
Fix index OOB when file ends with angle bracket

### DIFF
--- a/pdf/src/parser/lexer/mod.rs
+++ b/pdf/src/parser/lexer/mod.rs
@@ -177,12 +177,13 @@ impl<'a> Lexer<'a> {
                 }
                 return Ok((self.new_substr(start_pos..pos), pos));
             }
-            // TODO +- 1
-            if self.buf[pos] == b'<' && self.buf[pos+1] == b'<'
-                || self.buf[pos] == b'>' && self.buf[pos+1] == b'>' {
-                pos = self.advance_pos(pos)?;
 
+            if let Some(slice) = self.buf.get(pos..=pos+1) {
+                if slice == b"<<" || slice == b">>" {
+                    pos = self.advance_pos(pos)?;
+                }
             }
+
             pos = self.advance_pos(pos)?;
             return Ok((self.new_substr(start_pos..pos), pos));
         }

--- a/pdf/tests/xref.rs
+++ b/pdf/tests/xref.rs
@@ -2,3 +2,9 @@
 fn infinite_loop_invalid_file() {
     assert!(pdf::file::File::from_data(b"startxref%PDF-".as_ref()).is_err());
 }
+
+#[test]
+fn ending_angle_bracket() {
+    assert!(pdf::file::File::from_data(b"%PDF-startxref>".as_ref()).is_err());
+    assert!(pdf::file::File::from_data(b"%PDF-startxref<".as_ref()).is_err());
+}


### PR DESCRIPTION
I'm not sure what the `// TODO +- 1` means, does this fix whatever the comment was about?