### PR TITLE
replace  travis-ci with gh actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+on: push
+name: clippy & fmt
+jobs:
+  check-clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args:
+
+  check-fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+
+    - name: Check formatting
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+on: push
+name: test
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ target/
 **/*.rs.bk
 Cargo.lock
 **/*.orig
-**/\.*
 **/perf.data
 **/perf.data.old
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: rust
-
-script:
-  - cargo update
-  - cargo build
-  - cargo test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pdf-rs [![Build Status](https://travis-ci.com/pdf-rs/pdf.svg?branch=master)](https://travis-ci.com/pdf-rs/pdf)
+# pdf-rs [![test](https://github.com/pdf-rs/pdf/actions/workflows/test.yml/badge.svg)](https://github.com/pdf-rs/pdf/actions/workflows/test.yml) [![clippy&fmt](https://github.com/pdf-rs/pdf/actions/workflows/lint.yml/badge.svg)](https://github.com/pdf-rs/pdf/actions/workflows/lint.yml)
 Read, alter and write PDF files.
 
 **At the moment, you can only read PDF files.**


### PR DESCRIPTION
I would propose to replace travis-ci with gh actions. I get an 404 error when i visit [travis-ic](https://www.travis-ci.com/pdf-rs/pdf).
I added pipelines for tests, formatting and clippy. Formatting and clippy fail at the moment. I would open a second PR to fix this.
The badges should work after the first pipeline execution.