### PR TITLE
Remove and move unused dependencies

### DIFF
--- a/pdf/Cargo.toml
+++ b/pdf/Cargo.toml
@@ -20,15 +20,12 @@ jpeg2k = ["jp2k"]
 [dependencies]
 pdf_derive = { version = "0.1.22", path = "../pdf_derive" }
 snafu = "0.6.10"
-num-traits = "0.2.14"
 inflate = "0.4.5"
 deflate = "0.9.0"
 byteorder = "1.4.2"
 itertools = "0.10.0"
-ordermap = "0.4.2"
 memmap = { version = "0.7.0", optional = true }
 weezl = "0.1.4"
-glob = "0.3.0"
 chrono = "0.4.19"
 once_cell = "1.5.2"
 log = "0.4.14"
@@ -43,6 +40,9 @@ fax = "0.1.0"
 euclid = { version = "0.22.6", optional = true }
 utf16-ext = "0.1.0"
 jp2k = { git = "https://github.com/s3bk/jp2k", optional = true }
+
+[dev-dependencies]
+glob = "0.3.0"
 
 [lib]
 doctest = false


### PR DESCRIPTION
Just been doing some spring cleaning on some project dependencies and it looks like there were a couple of unused dependencies in the `pdf` crate along with `glob` being used just for tests