### PR TITLE
Point pdf crate link to repository

### DIFF
--- a/pdf/Cargo.toml
+++ b/pdf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pdf"
 version = "0.7.2"
 authors = ["Erlend Langseth <3rlendhl@gmail.com>", "Sebastian Köln <s3bk@protonmail.com>"]
-repository = "https://github.com/pdf-rs"
+repository = "https://github.com/pdf-rs/pdf"
 readme = "../README.md"
 keywords = ["pdf"]
 license = "MIT"


### PR DESCRIPTION
So it's not an issue on [the crates.io page](https://crates.io/crates/pdf), but it looks like [the lib.rs page](https://lib.rs/crates/pdf) won't link to the repository unless it appears to be a valid repo. Instead it looks like it falls back to linking to the source files stored on docs.rs.

This change just updates the link in the `pdf` crate to point to the pdf repo instead of the pdf-rs org