### PR TITLE
Fix or disable warnings and lints

### DIFF
--- a/pdf/examples/content.rs
+++ b/pdf/examples/content.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), PdfError> {
             println!("{:?}", c);
         }
 
-        let content = Content::from_ops(vec![
+        let _content = Content::from_ops(vec![
             Op::MoveTo { p: Point { x: 100., y: 100. } },
             Op::LineTo { p: Point { x: 100., y: 200. } },
             Op::LineTo { p: Point { x: 200., y: 100. } },

--- a/pdf/examples/read.rs
+++ b/pdf/examples/read.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use pdf::file::File;
 use pdf::object::*;
-use pdf::primitive::{Primitive, PdfString};
+use pdf::primitive::Primitive;
 use pdf::error::PdfError;
 
 

--- a/pdf/examples/text.rs
+++ b/pdf/examples/text.rs
@@ -6,11 +6,8 @@ use std::convert::TryInto;
 
 use pdf::file::File;
 use pdf::content::*;
-use pdf::primitive::Primitive;
 use pdf::font::*;
-use pdf::parser::Lexer;
-use pdf::parser::parse_with_lexer;
-use pdf::object::{Resolve, NoResolve, RcRef};
+use pdf::object::{Resolve, RcRef};
 use pdf::encoding::BaseEncoding;
 use pdf::error::PdfError;
 

--- a/pdf/src/content.rs
+++ b/pdf/src/content.rs
@@ -554,7 +554,7 @@ impl Object for FormXObject {
     }
 }
 
-
+#[allow(clippy::float_cmp)]  // TODO
 fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
     use Op::*;
     use std::io::Write;

--- a/pdf/src/crypt.rs
+++ b/pdf/src/crypt.rs
@@ -424,6 +424,7 @@ impl Decoder {
                 user_check_hash.update(password_encoded);
                 user_check_hash.update(user_validation_salt);
                 let user_hash_computed = user_check_hash.finalize();
+                #[allow(clippy::branches_sharing_code)]
                 if user_hash_computed.as_slice() == user_hash {
                     let mut intermediate_kdf_hash = Sha256::new();
                     intermediate_kdf_hash.update(password_encoded);

--- a/pdf/src/enc.rs
+++ b/pdf/src/enc.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]  // TODO
+
 use itertools::Itertools;
 use inflate::{inflate_bytes_zlib, inflate_bytes};
 use deflate::deflate_bytes;

--- a/pdf/src/enc.rs
+++ b/pdf/src/enc.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::many_single_char_names)]
 #![allow(dead_code)]  // TODO
 
 use itertools::Itertools;

--- a/pdf/src/font.rs
+++ b/pdf/src/font.rs
@@ -143,6 +143,7 @@ impl Widths {
             self.values.reserve(missing);
         }
     }
+    #[allow(clippy::float_cmp)]  // TODO
     fn set(&mut self, cid: usize, width: f32) {
         self._set(cid, width);
         debug_assert_eq!(self.get(cid), width);

--- a/pdf/src/object/function.rs
+++ b/pdf/src/object/function.rs
@@ -172,8 +172,8 @@ pub struct SampledFunction {
     order: Interpolation,
 }
 impl SampledFunction {
-    fn apply(&self, x: &[f32], out: &mut [f32]) -> Result<()> {
-        let idx: Vec<f32> = x.iter().zip(self.input.iter()).map(|(&x, dim)| dim.map(x)).collect();
+    fn apply(&self, x: &[f32], _out: &mut [f32]) -> Result<()> {
+        let _idx: Vec<f32> = x.iter().zip(self.input.iter()).map(|(&x, dim)| dim.map(x)).collect();
         match self.order {
             Interpolation::Linear => {
                 unimplemented!()

--- a/pdf/src/object/function.rs
+++ b/pdf/src/object/function.rs
@@ -161,6 +161,7 @@ struct SampledFunctionOutput {
 #[derive(Debug, Clone)]
 enum Interpolation {
     Linear,
+    #[allow(dead_code)]  // TODO
     Cubic,
 }
 

--- a/pdf/src/object/mod.rs
+++ b/pdf/src/object/mod.rs
@@ -78,7 +78,7 @@ pub trait ToDict: ObjectWrite {
 pub trait SubType<T> {}
 
 pub trait Trace {
-    fn trace(&self, cb: &mut impl FnMut(PlainRef)) {}
+    fn trace(&self, _cb: &mut impl FnMut(PlainRef)) {}
 }
 
 ///////

--- a/pdf/tests/integration.rs
+++ b/pdf/tests/integration.rs
@@ -1,5 +1,4 @@
 use std::str;
-use std::rc::Rc;
 use pdf::file::File;
 use pdf::object::*;
 use pdf::parser::parse;


### PR DESCRIPTION
These aren't all necessarily the best fixes (and I've left a few TODOs in places that seem like good candidates for a better fix), but it gets the code to a state where you can build and run clippy without any warnings or lints, which is helpful to avoid accidentally introducing new ones.