### PR TITLE
Avoid alloc from utf16be

### DIFF
--- a/pdf/src/primitive.rs
+++ b/pdf/src/primitive.rs
@@ -1,27 +1,27 @@
 use crate::error::*;
-use crate::object::{PlainRef, Resolve, Object, NoResolve, ObjectWrite, Updater};
+use crate::object::{NoResolve, Object, ObjectWrite, PlainRef, Resolve, Updater};
 
-use std::collections::{btree_map, BTreeMap};
-use std::{str, fmt, io};
-use std::ops::{Index, Range};
 use chrono::{DateTime, FixedOffset};
-use std::ops::Deref;
-use std::convert::TryInto;
-use std::borrow::{Borrow, Cow};
 use itertools::Itertools;
+use std::borrow::{Borrow, Cow};
+use std::collections::{btree_map, BTreeMap};
+use std::convert::TryInto;
+use std::ops::Deref;
+use std::ops::{Index, Range};
+use std::{fmt, io, str};
 
 #[derive(Clone, Debug)]
 pub enum Primitive {
     Null,
-    Integer (i32),
-    Number (f32),
-    Boolean (bool),
-    String (PdfString),
-    Stream (PdfStream),
-    Dictionary (Dictionary),
-    Array (Vec<Primitive>),
-    Reference (PlainRef),
-    Name (String),
+    Integer(i32),
+    Number(f32),
+    Boolean(bool),
+    String(PdfString),
+    Stream(PdfStream),
+    Dictionary(Dictionary),
+    Array(Vec<Primitive>),
+    Reference(PlainRef),
+    Name(String),
 }
 
 impl fmt::Display for Primitive {
@@ -36,7 +36,7 @@ impl fmt::Display for Primitive {
             Primitive::Dictionary(ref d) => d.fmt(f),
             Primitive::Array(ref arr) => write!(f, "[{}]", arr.iter().format(", ")),
             Primitive::Reference(r) => write!(f, "@{}", r.id),
-            Primitive::Name(ref s) => write!(f, "/{}", s)
+            Primitive::Name(ref s) => write!(f, "/{}", s),
         }
     }
 }
@@ -51,16 +51,21 @@ impl Primitive {
             Primitive::Stream(ref s) => s.serialize(out)?,
             Primitive::Dictionary(ref d) => d.serialize(out, level)?,
             Primitive::Array(ref arr) => serialize_list(arr, out, level)?,
-            Primitive::Reference(r) =>  write!(out, "{} {} R", r.id, r.gen)?,
+            Primitive::Reference(r) => write!(out, "{} {} R", r.id, r.gen)?,
             Primitive::Name(ref s) => serialize_name(s, out)?,
         }
         Ok(())
     }
     pub fn array<O, T, I, U>(i: I, update: &mut U) -> Result<Primitive>
-        where O: ObjectWrite, I: Iterator<Item=T>,
-        T: Borrow<O>, U: Updater
+    where
+        O: ObjectWrite,
+        I: Iterator<Item = T>,
+        T: Borrow<O>,
+        U: Updater,
     {
-        i.map(|t| t.borrow().to_primitive(update)).collect::<Result<_>>().map(Primitive::Array)
+        i.map(|t| t.borrow().to_primitive(update))
+            .collect::<Result<_>>()
+            .map(Primitive::Array)
     }
     pub fn name(name: impl Into<String>) -> Primitive {
         Primitive::Name(name.into())
@@ -69,13 +74,13 @@ impl Primitive {
 
 fn serialize_list(arr: &[Primitive], out: &mut impl io::Write, level: usize) -> Result<()> {
     let mut parts = arr.iter();
-    write!(out, "{:w$}[", "", w=2*level)?;
+    write!(out, "{:w$}[", "", w = 2 * level)?;
     if let Some(first) = parts.next() {
-        first.serialize(out, level+1)?;
+        first.serialize(out, level + 1)?;
     }
     for p in parts {
         write!(out, " ")?;
-        p.serialize(out, level+1)?;
+        p.serialize(out, level + 1)?;
     }
     write!(out, "]")?;
     Ok(())
@@ -87,7 +92,7 @@ pub fn serialize_name(s: &str, out: &mut impl io::Write) -> Result<()> {
         match b {
             '\\' | '(' | ')' => write!(out, r"\")?,
             c if c > '~' => panic!("only ASCII"),
-            _ => ()
+            _ => (),
         }
         write!(out, "{}", b)?;
     }
@@ -111,11 +116,13 @@ impl<'a> fmt::Display for Name<'a> {
 /// Primitive Dictionary type.
 #[derive(Default, Clone)]
 pub struct Dictionary {
-    dict: BTreeMap<String, Primitive>
+    dict: BTreeMap<String, Primitive>,
 }
 impl Dictionary {
     pub fn new() -> Dictionary {
-        Dictionary { dict: BTreeMap::new()}
+        Dictionary {
+            dict: BTreeMap::new(),
+        }
     }
     pub fn len(&self) -> usize {
         self.dict.len()
@@ -137,12 +144,10 @@ impl Dictionary {
     }
     /// like remove, but takes the name of the calling type and returns `PdfError::MissingEntry` if the entry is not found
     pub fn require(&mut self, typ: &'static str, key: &str) -> Result<Primitive> {
-        self.remove(key).ok_or(
-            PdfError::MissingEntry {
-                typ,
-                field: key.into()
-            }
-        )
+        self.remove(key).ok_or(PdfError::MissingEntry {
+            typ,
+            field: key.into(),
+        })
     }
     /// assert that the given key/value pair is in the dictionary (`required=true`),
     /// or the key is not present at all (`required=false`)
@@ -154,14 +159,17 @@ impl Dictionary {
                     Err(PdfError::KeyValueMismatch {
                         key: key.into(),
                         value: value.into(),
-                        found: ty.into()
+                        found: ty.into(),
                     })
                 } else {
                     Ok(())
                 }
-            },
-            None if required => Err(PdfError::MissingEntry { typ, field: key.into() }),
-            None => Ok(())
+            }
+            None if required => Err(PdfError::MissingEntry {
+                typ,
+                field: key.into(),
+            }),
+            None => Ok(()),
         }
     }
 }
@@ -180,11 +188,11 @@ impl Dictionary {
     fn serialize(&self, out: &mut impl io::Write, level: usize) -> Result<()> {
         writeln!(out, "<<")?;
         for (key, val) in self.iter() {
-            write!(out, "{:w$}/{} ", "", key, w=2*level+2)?;
-            val.serialize(out, level+2)?;
+            write!(out, "{:w$}/{} ", "", key, w = 2 * level + 2)?;
+            val.serialize(out, level + 2)?;
             writeln!(out)?;
         }
-        writeln!(out, "{:w$}>>", "", w=2*level)?;
+        writeln!(out, "{:w$}>>", "", w = 2 * level)?;
         Ok(())
     }
 }
@@ -199,7 +207,12 @@ impl fmt::Debug for Dictionary {
 }
 impl fmt::Display for Dictionary {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "<{}>", self.iter().format_with(", ", |(k, v), f| f(&format_args!("{}={}", k, v))))
+        write!(
+            f,
+            "<{}>",
+            self.iter()
+                .format_with(", ", |(k, v), f| f(&format_args!("{}={}", k, v)))
+        )
     }
 }
 impl<'a> Index<&'a str> for Dictionary {
@@ -232,16 +245,19 @@ pub struct PdfStream {
 impl Object for PdfStream {
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         match p {
-            Primitive::Stream (stream) => Ok(stream),
-            Primitive::Reference (r) => PdfStream::from_primitive(resolve.resolve(r)?, resolve),
-            p => Err(PdfError::UnexpectedPrimitive {expected: "Stream", found: p.get_debug_name()})
+            Primitive::Stream(stream) => Ok(stream),
+            Primitive::Reference(r) => PdfStream::from_primitive(resolve.resolve(r)?, resolve),
+            p => Err(PdfError::UnexpectedPrimitive {
+                expected: "Stream",
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
 impl PdfStream {
     pub fn serialize(&self, out: &mut impl io::Write) -> Result<()> {
         self.info.serialize(out, 0)?;
-        
+
         writeln!(out, "stream")?;
         out.write_all(&self.data)?;
         writeln!(out, "\nendstream")?;
@@ -249,14 +265,13 @@ impl PdfStream {
     }
 }
 
-
 macro_rules! unexpected_primitive {
-    ($expected:ident, $found:expr) => (
+    ($expected:ident, $found:expr) => {
         Err(PdfError::UnexpectedPrimitive {
             expected: stringify!($expected),
-            found: $found
+            found: $found,
         })
-    )
+    };
 }
 
 /// Primitive String type.
@@ -270,9 +285,9 @@ impl fmt::Debug for PdfString {
         for &b in &self.data {
             match b {
                 b'"' => write!(f, "\\\"")?,
-                b' ' ..= b'~' => write!(f, "{}", b as char)?,
-                o @ 0 ..= 7  => write!(f, "\\{}", o)?,
-                x => write!(f, "\\x{:02x}", x)?
+                b' '..=b'~' => write!(f, "{}", b as char)?,
+                o @ 0..=7 => write!(f, "\\{}", o)?,
+                x => write!(f, "\\x{:02x}", x)?,
             }
         }
         write!(f, "\"")
@@ -281,7 +296,7 @@ impl fmt::Debug for PdfString {
 impl Object for PdfString {
     fn from_primitive(p: Primitive, r: &impl Resolve) -> Result<Self> {
         match p {
-            Primitive::String (string) => Ok(string),
+            Primitive::String(string) => Ok(string),
             Primitive::Reference(id) => PdfString::from_primitive(r.resolve(id)?, &NoResolve),
             _ => unexpected_primitive!(String, p.get_debug_name()),
         }
@@ -306,7 +321,7 @@ impl PdfString {
             for &b in &self.data {
                 match b {
                     b'\\' | b'(' | b')' => write!(out, r"\")?,
-                    _ => ()
+                    _ => (),
                 }
                 out.write_all(&[b])?;
             }
@@ -323,9 +338,7 @@ impl AsRef<[u8]> for PdfString {
 
 impl PdfString {
     pub fn new(data: Vec<u8>) -> PdfString {
-        PdfString {
-            data
-        }
+        PdfString { data }
     }
     pub fn as_bytes(&self) -> &[u8] {
         &self.data
@@ -333,7 +346,10 @@ impl PdfString {
     pub fn as_str(&self) -> Result<Cow<str>> {
         if self.data.starts_with(&[0xfe, 0xff]) {
             // FIXME: avoid extra allocation
-            let utf16: Vec<u16> = self.data[2..].chunks(2).map(|c| (c[0] as u16) << 8 | c[1] as u16).collect();
+            let utf16: Vec<u16> = self.data[2..]
+                .chunks(2)
+                .map(|c| (c[0] as u16) << 8 | c[1] as u16)
+                .collect();
             Ok(Cow::Owned(String::from_utf16(&utf16)?))
         } else {
             Ok(Cow::Borrowed(str::from_utf8(&self.data)?))
@@ -347,7 +363,6 @@ impl PdfString {
     }
 }
 
-
 // TODO:
 // Noticed some inconsistency here.. I think to_* and as_* should not take Resolve, and not accept
 // Reference. Only from_primitive() for the respective type resolves References.
@@ -356,53 +371,53 @@ impl Primitive {
     pub fn get_debug_name(&self) -> &'static str {
         match *self {
             Primitive::Null => "Null",
-            Primitive::Integer (..) => "Integer",
-            Primitive::Number (..) => "Number",
-            Primitive::Boolean (..) => "Boolean",
-            Primitive::String (..) => "String",
-            Primitive::Stream (..) => "Stream",
-            Primitive::Dictionary (..) => "Dictionary",
-            Primitive::Array (..) => "Array",
-            Primitive::Reference (..) => "Reference",
-            Primitive::Name (..) => "Name",
+            Primitive::Integer(..) => "Integer",
+            Primitive::Number(..) => "Number",
+            Primitive::Boolean(..) => "Boolean",
+            Primitive::String(..) => "String",
+            Primitive::Stream(..) => "Stream",
+            Primitive::Dictionary(..) => "Dictionary",
+            Primitive::Array(..) => "Array",
+            Primitive::Reference(..) => "Reference",
+            Primitive::Name(..) => "Name",
         }
     }
     pub fn as_integer(&self) -> Result<i32> {
         match *self {
             Primitive::Integer(n) => Ok(n),
-            ref p => unexpected_primitive!(Integer, p.get_debug_name())
+            ref p => unexpected_primitive!(Integer, p.get_debug_name()),
         }
     }
     pub fn as_u32(&self) -> Result<u32> {
         match *self {
             Primitive::Integer(n) if n >= 0 => Ok(n as u32),
             Primitive::Integer(_) => bail!("negative integer"),
-            ref p => unexpected_primitive!(Integer, p.get_debug_name())
+            ref p => unexpected_primitive!(Integer, p.get_debug_name()),
         }
     }
     pub fn as_number(&self) -> Result<f32> {
         match *self {
             Primitive::Integer(n) => Ok(n as f32),
             Primitive::Number(f) => Ok(f),
-            ref p => unexpected_primitive!(Number, p.get_debug_name())
+            ref p => unexpected_primitive!(Number, p.get_debug_name()),
         }
     }
     pub fn as_bool(&self) -> Result<bool> {
         match *self {
-            Primitive::Boolean (b) => Ok(b),
-            ref p => unexpected_primitive!(Number, p.get_debug_name())
+            Primitive::Boolean(b) => Ok(b),
+            ref p => unexpected_primitive!(Number, p.get_debug_name()),
         }
     }
     pub fn as_name(&self) -> Result<&str> {
         match self {
             Primitive::Name(ref name) => Ok(name.as_str()),
-            p => unexpected_primitive!(Name, p.get_debug_name())
+            p => unexpected_primitive!(Name, p.get_debug_name()),
         }
     }
     pub fn as_string(&self) -> Result<&PdfString> {
         match self {
             Primitive::String(ref data) => Ok(data),
-            p => unexpected_primitive!(String, p.get_debug_name())
+            p => unexpected_primitive!(String, p.get_debug_name()),
         }
     }
     pub fn as_str(&self) -> Option<Cow<str>> {
@@ -412,13 +427,13 @@ impl Primitive {
     pub fn as_array(&self) -> Result<&[Primitive]> {
         match self {
             Primitive::Array(ref v) => Ok(v),
-            p => unexpected_primitive!(Array, p.get_debug_name())
+            p => unexpected_primitive!(Array, p.get_debug_name()),
         }
     }
     pub fn into_reference(self) -> Result<PlainRef> {
         match self {
             Primitive::Reference(id) => Ok(id),
-            p => unexpected_primitive!(Reference, p.get_debug_name())
+            p => unexpected_primitive!(Reference, p.get_debug_name()),
         }
     }
     /// Does accept a Reference
@@ -426,36 +441,36 @@ impl Primitive {
         match self {
             Primitive::Array(v) => Ok(v),
             Primitive::Reference(id) => r.resolve(id)?.into_array(r),
-            p => unexpected_primitive!(Array, p.get_debug_name())
+            p => unexpected_primitive!(Array, p.get_debug_name()),
         }
     }
     pub fn into_dictionary(self, r: &impl Resolve) -> Result<Dictionary> {
         match self {
             Primitive::Dictionary(dict) => Ok(dict),
             Primitive::Reference(id) => r.resolve(id)?.into_dictionary(r),
-            p => unexpected_primitive!(Dictionary, p.get_debug_name())
+            p => unexpected_primitive!(Dictionary, p.get_debug_name()),
         }
     }
     /// Doesn't accept a Reference
     pub fn into_name(self) -> Result<String> {
         match self {
             Primitive::Name(name) => Ok(name),
-            p => unexpected_primitive!(Name, p.get_debug_name())
+            p => unexpected_primitive!(Name, p.get_debug_name()),
         }
     }
     /// Doesn't accept a Reference
     pub fn into_string(self) -> Result<PdfString> {
         match self {
             Primitive::String(data) => Ok(data),
-            p => unexpected_primitive!(String, p.get_debug_name())
+            p => unexpected_primitive!(String, p.get_debug_name()),
         }
     }
     /// Doesn't accept a Reference
     pub fn into_stream(self, _r: &impl Resolve) -> Result<PdfStream> {
         match self {
-            Primitive::Stream (s) => Ok(s),
+            Primitive::Stream(s) => Ok(s),
             // Primitive::Reference (id) => r.resolve(id)?.to_stream(r),
-            p => unexpected_primitive!(Stream, p.get_debug_name())
+            p => unexpected_primitive!(Stream, p.get_debug_name()),
         }
     }
 }
@@ -482,33 +497,33 @@ impl<'a> From<Name<'a>> for Primitive {
 }
 impl From<PdfString> for Primitive {
     fn from(x: PdfString) -> Primitive {
-        Primitive::String (x)
+        Primitive::String(x)
     }
 }
 impl From<PdfStream> for Primitive {
     fn from(x: PdfStream) -> Primitive {
-        Primitive::Stream (x)
+        Primitive::Stream(x)
     }
 }
 impl From<Dictionary> for Primitive {
     fn from(x: Dictionary) -> Primitive {
-        Primitive::Dictionary (x)
+        Primitive::Dictionary(x)
     }
 }
 impl From<Vec<Primitive>> for Primitive {
     fn from(x: Vec<Primitive>) -> Primitive {
-        Primitive::Array (x)
+        Primitive::Array(x)
     }
 }
 
 impl From<PlainRef> for Primitive {
     fn from(x: PlainRef) -> Primitive {
-        Primitive::Reference (x)
+        Primitive::Reference(x)
     }
 }
 impl From<String> for Primitive {
     fn from(x: String) -> Primitive {
-        Primitive::Name (x)
+        Primitive::Name(x)
     }
 }
 impl<'a> TryInto<f32> for &'a Primitive {
@@ -530,8 +545,8 @@ impl<'a> TryInto<Name<'a>> for &'a Primitive {
             &Primitive::Name(ref s) => Ok(Name(s.as_str())),
             p => Err(PdfError::UnexpectedPrimitive {
                 expected: "Name",
-                found: p.get_debug_name()
-            })
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
@@ -549,8 +564,8 @@ impl<'a> TryInto<&'a [u8]> for &'a Primitive {
             Primitive::String(ref s) => Ok(s.as_bytes()),
             ref p => Err(PdfError::UnexpectedPrimitive {
                 expected: "Name or String",
-                found: p.get_debug_name()
-            })
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
@@ -562,8 +577,8 @@ impl<'a> TryInto<Cow<'a, str>> for &'a Primitive {
             Primitive::String(ref s) => Ok(s.as_str()?),
             ref p => Err(PdfError::UnexpectedPrimitive {
                 expected: "Name or String",
-                found: p.get_debug_name()
-            })
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
@@ -575,32 +590,30 @@ impl<'a> TryInto<String> for &'a Primitive {
             Primitive::String(ref s) => Ok(s.as_str()?.into_owned()),
             ref p => Err(PdfError::UnexpectedPrimitive {
                 expected: "Name or String",
-                found: p.get_debug_name()
-            })
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
 
 fn parse_or<T: str::FromStr + Clone>(buffer: &str, range: Range<usize>, default: T) -> T {
-    buffer.get(range)
+    buffer
+        .get(range)
         .map(|s| str::parse::<T>(s).unwrap_or_else(|_| default.clone()))
         .unwrap_or(default)
 }
 
 impl Object for DateTime<FixedOffset> {
     fn from_primitive(p: Primitive, _: &impl Resolve) -> Result<Self> {
-        use chrono::{NaiveDateTime, NaiveDate, NaiveTime};
+        use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
         match p {
-            Primitive::String (PdfString {data}) => {
+            Primitive::String(PdfString { data }) => {
                 let s = str::from_utf8(&data)?;
                 let len = s.len();
                 if len > 2 && &s[0..2] == "D:" {
-
                     let year = match s.get(2..6) {
-                        Some(year) => {
-                            str::parse::<i32>(year)?
-                        }
-                        None => bail!("Missing obligatory year in date")
+                        Some(year) => str::parse::<i32>(year)?,
+                        None => bail!("Missing obligatory year in date"),
                     };
                     let month = parse_or(s, 6..8, 1);
                     let day = parse_or(s, 8..10, 1);
@@ -612,11 +625,12 @@ impl Object for DateTime<FixedOffset> {
                     let tz = FixedOffset::east(tz_hour * 60 + tz_minute);
 
                     Ok(DateTime::from_utc(
-                            NaiveDateTime::new(NaiveDate::from_ymd(year, month, day),
-                                               NaiveTime::from_hms(hour, minute, second)),
-                          tz
-                      ))
-
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd(year, month, day),
+                            NaiveTime::from_hms(hour, minute, second),
+                        ),
+                        tz,
+                    ))
                 } else {
                     bail!("Failed parsing date");
                 }
@@ -625,4 +639,3 @@ impl Object for DateTime<FixedOffset> {
         }
     }
 }
-


### PR DESCRIPTION
sorry diff for PR looks insane due to rustfmt, it's default active in my editor. please checkout f1aff30 to see the actual changes

I stumbled on this fixme by chance, so I figured I give it a go. One allocation less than before, completely avoiding it is not doable afaik, because mem-transmute would yield incorrect results on little-endian machines.