### PR TITLE
Remove pdfstring as str

### DIFF
--- a/pdf/Cargo.toml
+++ b/pdf/Cargo.toml
@@ -22,7 +22,6 @@ pdf_derive = { version = "0.1.22", path = "../pdf_derive" }
 snafu = "0.6.10"
 inflate = "0.4.5"
 deflate = "0.9.0"
-byteorder = "1.4.2"
 itertools = "0.10.0"
 memmap = { version = "0.7.0", optional = true }
 weezl = "0.1.4"
@@ -38,7 +37,6 @@ stringprep = "0.1.2"
 sha2 = "0.9.2"
 fax = "0.1.0"
 euclid = { version = "0.22.6", optional = true }
-utf16-ext = "0.1.0"
 jp2k = { git = "https://github.com/s3bk/jp2k", optional = true }
 
 [dev-dependencies]

--- a/pdf/examples/metadata.rs
+++ b/pdf/examples/metadata.rs
@@ -12,9 +12,9 @@ fn main() -> Result<(), PdfError> {
     let file = File::<Vec<u8>>::open(&path).unwrap();
     if let Some(ref info) = file.trailer.info_dict {
         info.iter()
-            .filter(|(_, primitive)| primitive.as_str().is_some())
+            .filter(|(_, primitive)| primitive.to_string_lossy().is_ok())
             .for_each(|(key, value)| {
-                eprintln!("{:>15}: {}", key, value.as_str().unwrap());
+                eprintln!("{:>15}: {}", key, value.to_string_lossy().unwrap());
             });
     }
 

--- a/pdf/examples/names.rs
+++ b/pdf/examples/names.rs
@@ -4,7 +4,7 @@ use std::env::args;
 use std::fmt;
 use std::collections::HashMap;
 use pdf::file::File;
-use pdf::object::{*};
+use pdf::object::*;
 use pdf::primitive::PdfString;
 
 struct Indent(usize);
@@ -14,17 +14,17 @@ impl fmt::Display for Indent {
             write!(f, "    ")?;
         }
         Ok(())
-    } 
+    }
 }
 
 fn walk_outline(r: &impl Resolve, mut node: RcRef<OutlineItem>, map: &impl Fn(&str) -> usize, depth: usize) {
     let indent = Indent(depth);
     loop {
         if let Some(ref title) = node.title {
-            println!("{}title: {:?}", indent, title.as_str().unwrap());
+            println!("{}title: {:?}", indent, title.to_string_lossy());
         }
         if let Some(ref dest) = node.dest {
-            let name = dest.as_str().unwrap();
+            let name = dest.to_string_lossy().unwrap();
             let page_nr = map(&name);
             println!("{}dest: {:?} -> page nr. {:?}", indent, name, page_nr);
         }
@@ -44,7 +44,7 @@ fn walk_outline(r: &impl Resolve, mut node: RcRef<OutlineItem>, map: &impl Fn(&s
 fn main() {
     let path = args().nth(1).expect("no file given");
     println!("read: {}", path);
-    
+
     let file = File::<Vec<u8>>::open(&path).unwrap();
     let catalog = file.get_root();
 
@@ -53,8 +53,8 @@ fn main() {
     let mut count = 0;
     let mut dests_cb = |key: &PdfString, val: &Dest| {
         //println!("{:?} {:?}", key, val);
-        pages_map.insert(key.as_str().unwrap().into_owned(), val.page.get_inner());
-        
+        pages_map.insert(key.to_string_lossy().unwrap(), val.page.get_inner());
+
         count += 1;
     };
 
@@ -80,7 +80,7 @@ fn main() {
         }
     }
     add_tree(&file, &mut pages, &catalog.pages, &mut 0);
-    
+
     let get_page_nr = |name: &str| -> usize {
         let page = pages_map[name];
         pages[&page]
@@ -93,6 +93,6 @@ fn main() {
         }
     }
 
-    
+
     println!("{} items", count);
 }

--- a/pdf/src/error.rs
+++ b/pdf/src/error.rs
@@ -22,36 +22,36 @@ pub enum PdfError {
 
     #[snafu(display("Unexpected token '{}' at {} - expected '{}'", lexeme, pos, expected))]
     UnexpectedLexeme {pos: usize, lexeme: String, expected: &'static str},
-    
+
     #[snafu(display("Expecting an object, encountered {} at pos {}. Rest:\n{}\n\n((end rest))", first_lexeme, pos, rest))]
     UnknownType {pos: usize, first_lexeme: String, rest: String},
-    
+
     #[snafu(display("Unknown variant '{}' for enum {}", name, id))]
     UnknownVariant { id: &'static str, name: String },
-    
+
     #[snafu(display("'{}' not found.", word))]
     NotFound { word: String },
-    
+
     #[snafu(display("Cannot follow reference during parsing - no resolve fn given (most likely /Length of Stream)."))]
     Reference, // TODO: which one?
-    
+
     #[snafu(display("Erroneous 'type' field in xref stream - expected 0, 1 or 2, found {}", found))]
     XRefStreamType { found: u64 },
-    
+
     #[snafu(display("Parsing read past boundary of Contents."))]
     ContentReadPastBoundary,
-    
+
     //////////////////
     // Encode/decode
     #[snafu(display("Hex decode error. Position {}, bytes {:?}", pos, bytes))]
     HexDecode {pos: usize, bytes: [u8; 2]},
-    
+
     #[snafu(display("Ascii85 tail error"))]
     Ascii85TailError,
-    
+
     #[snafu(display("Failed to convert '{}' into PredictorType", n))]
     IncorrectPredictorType {n: u8},
-    
+
     //////////////////
     // Dictionary
     #[snafu(display("Can't parse field {} of struct {}.", field, typ))]
@@ -60,28 +60,28 @@ pub enum PdfError {
         field: &'static str,
         source: Box<PdfError>
     },
-    
+
     #[snafu(display("Field /{} is missing in dictionary for type {}.", field, typ))]
     MissingEntry {
         typ: &'static str,
         field: String
     },
-    
+
     #[snafu(display("Expected to find value {} for key {}. Found {} instead.", value, key, found))]
     KeyValueMismatch {
         key: String,
         value: String,
         found: String,
     },
-    
+
     #[snafu(display("Expected dictionary /Type = {}. Found /Type = {}.", expected, found))]
     WrongDictionaryType {expected: String, found: String},
-    
+
     //////////////////
     // Misc
     #[snafu(display("Tried to dereference free object nr {}.", obj_nr))]
     FreeObject {obj_nr: u64},
-    
+
     #[snafu(display("Tried to dereference non-existing object nr {}.", obj_nr))]
     NullRef {obj_nr: u64},
 
@@ -95,16 +95,16 @@ pub enum PdfError {
     */
     #[snafu(display("Object stream index out of bounds ({}/{}).", index, max))]
     ObjStmOutOfBounds {index: usize, max: usize},
-    
+
     #[snafu(display("Page out of bounds ({}/{}).", page_nr, max))]
     PageOutOfBounds {page_nr: u32, max: u32},
-    
+
     #[snafu(display("Page {} could not be found in the page tree.", page_nr))]
     PageNotFound {page_nr: u32},
-    
+
     #[snafu(display("Entry {} in xref table unspecified", id))]
     UnspecifiedXRefEntry {id: ObjNr},
-    
+
     #[snafu(display("Invalid password"))]
     InvalidPassword,
 
@@ -116,10 +116,10 @@ pub enum PdfError {
 
     #[snafu(display("IO Error"))]
     Io { source: io::Error },
-    
+
     #[snafu(display("{}", msg))]
     Other { msg: String },
-    
+
     #[snafu(display("NoneError at {}:{}:{}", file, line, column))]
     NoneError { file: &'static str, line: u32, column: u32 },
 
@@ -137,6 +137,9 @@ pub enum PdfError {
 
     #[snafu(display("UTF16 decode error"))]
     Utf16Decode,
+
+    #[snafu(display("UTF8 decode error"))]
+    Utf8Decode,
 
     #[snafu(display("CID decode error"))]
     CidDecode,
@@ -165,7 +168,7 @@ fn trace(err: &dyn Error, depth: usize) {
         trace(source, depth+1);
     }
 }
-    
+
 
 pub type Result<T, E=PdfError> = std::result::Result<T, E>;
 

--- a/pdf/src/font.rs
+++ b/pdf/src/font.rs
@@ -445,7 +445,7 @@ pub fn utf16be_to_string_lossy(data: &[u8]) -> pdf::error::Result<String> {
         .collect())
 }
 /// converts UTF16-BE to a string errors out in illegal/unknonw characters
-fn utf16be_to_string(data: &[u8]) -> pdf::error::Result<String> {
+pub fn utf16be_to_string(data: &[u8]) -> pdf::error::Result<String> {
     utf16be_to_char(data)
         .map(|r| r.map_err(|_| PdfError::Utf16Decode))
         .collect()


### PR DESCRIPTION
- avoid extra allocations decoding utf-16be
- deprecated PdfString::as_str()
- removed dependencies, utf16be decoding can be done with pdf-lib only now