### PR TITLE
Switch out `memmap` for `memmap2`

### DIFF
--- a/pdf/Cargo.toml
+++ b/pdf/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 description = "PDF reader"
 
 [features]
-mmap = ["memmap"]
+mmap = ["memmap2"]
 dump = ["tempfile"]
 threads = ["jpeg-decoder/default"]
 standard-fonts = []
@@ -23,7 +23,7 @@ snafu = "0.6.10"
 inflate = "0.4.5"
 deflate = "0.9.0"
 itertools = "0.10.0"
-memmap = { version = "0.7.0", optional = true }
+memmap2 = { version = "0.5.0", optional = true }
 weezl = "0.1.4"
 chrono = "0.4.19"
 once_cell = "1.5.2"


### PR DESCRIPTION
`memmap` hasn't been maintained for a while (https://github.com/danburkert/memmap-rs/issues/90). `memmap2` currently exists as an actively maintained fork instead

`memmap` not being maintained doesn't seem too pressing, but it does get flagged by `cargo audit` for being unmaintained