### PR TITLE
fix unnecessary panic with inline image

### DIFF
--- a/pdf/src/parser/lexer/mod.rs
+++ b/pdf/src/parser/lexer/mod.rs
@@ -284,6 +284,9 @@ impl<'a> Lexer<'a> {
         let start = self.pos;
         let mut matched = 0;
         loop {
+            if self.pos >= self.buf.len() {
+                return None
+            }
             if self.buf[self.pos] == substr[matched] {
                 matched += 1;
             } else {
@@ -291,9 +294,6 @@ impl<'a> Lexer<'a> {
             }
             if matched == substr.len() {
                 break;
-            }
-            if self.pos >= self.buf.len() {
-                return None
             }
             self.pos += 1;
         }


### PR DESCRIPTION
Hey, another one which fixes 2 invoices in my test-base. The way I see it is that is that behavior is identical, minus the panic (which allows any kind of recovery). I leave this to your judgement, becuase I don't handle any inline images in my code (they are there though since parsing them panics at this specific line). 