### PR TITLE
Add preliminary support for PDF annotations

### DIFF
--- a/pdf/src/build.rs
+++ b/pdf/src/build.rs
@@ -10,6 +10,7 @@ pub struct PageBuilder {
     pub trim_box: Option<Rect>,
     pub resources: Option<MaybeRef<Resources>>,
     pub rotate: i32,
+    pub annots: Option<Vec<MaybeRef<Annot>>>,
 }
 impl PageBuilder {
     pub fn from_content(content: Content) -> PageBuilder {
@@ -26,6 +27,7 @@ impl PageBuilder {
             trim_box: page.trim_box,
             resources: Some(page.resources()?.clone()),
             rotate: page.rotate,
+            annots: page.annots.clone(),
         })
     }
     pub fn size(&mut self, width: f32, height: f32) {
@@ -76,6 +78,7 @@ impl CatalogBuilder {
                 trim_box: page.trim_box,
                 resources: page.resources,
                 rotate: page.rotate,
+                annots: page.annots,
             };
             update.fulfill(promise, PagesNode::Leaf(page))?;
         }

--- a/pdf/src/content.rs
+++ b/pdf/src/content.rs
@@ -885,7 +885,7 @@ impl Object for Matrix {
 impl ObjectWrite for Matrix {
     fn to_primitive(&self, update: &mut impl Updater) -> Result<Primitive> {
         let Matrix { a, b, c, d, e, f } = *self;
-        Primitive::array::<f32, _, _, _>([a, b, c, d, e, f].into_iter(), update)
+        Primitive::array::<f32, _, _, _>([a, b, c, d, e, f].iter(), update)
     }
 }
 #[cfg(feature = "euclid")]

--- a/pdf/src/error.rs
+++ b/pdf/src/error.rs
@@ -94,7 +94,7 @@ pub enum PdfError {
     #[snafu(display("Tried to dereference non-existing object nr {}.", obj_nr))]
     NullRef {obj_nr: u64},
 
-    #[snafu(display("Expected primitive {}, found primive {} instead.", expected, found))]
+    #[snafu(display("Expected primitive {}, found primitive {} instead.", expected, found))]
     UnexpectedPrimitive {expected: &'static str, found: &'static str},
     /*
     WrongObjectType {expected: &'static str, found: &'static str} {

--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -413,7 +413,7 @@ impl ObjectWrite for Pattern {
         match self {
             Pattern::Dict(ref d) => d.to_primitive(update),
             Pattern::Stream(ref d, ref ops) => {
-                let data = serialize_ops(&ops)?;
+                let data = serialize_ops(ops)?;
                 let stream = Stream::new_with_filters(d.clone(), data, vec![]);
                 stream.to_primitive(update)
             }
@@ -926,7 +926,7 @@ impl<T: Object+DataSize> NameTree<T> {
 impl<T: Object> Object for NameTree<T> {
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         let mut dict = t!(p.resolve(resolve)?.into_dictionary());
-        
+
         // Quite long function..=
         let limits = match dict.remove("Limits") {
             Some(limits) => {
@@ -959,7 +959,7 @@ impl<T: Object> Object for NameTree<T> {
                 let names = names.resolve(resolve)?.into_array()?;
                 let mut new_names = Vec::new();
                 for pair in names.chunks(2) {
-                    let name = pair[0].clone().into_string()?;
+                    let name = pair[0].clone().resolve(resolve)?.into_string()?;
                     let value = t!(T::from_primitive(pair[1].clone(), resolve));
                     new_names.push((name, value));
                 }
@@ -1035,7 +1035,7 @@ impl Dest {
                     ref p => return Err(PdfError::UnexpectedPrimitive { expected: "Number | Integer | Null", found: p.get_debug_name() }),
                 },
                 zoom: match array.get(4) {
-                    Some(&Primitive::Null) => 0.0,
+                    Some(Primitive::Null) => 0.0,
                     Some(&Primitive::Integer(n)) => n as f32,
                     Some(&Primitive::Number(f)) => f,
                     Some(ref p) => return Err(PdfError::UnexpectedPrimitive { expected: "Number | Integer | Null", found: p.get_debug_name() }),

--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -260,6 +260,9 @@ pub struct Page {
 
     #[pdf(key="Rotate", default="0")]
     pub rotate: i32,
+
+    #[pdf(key="Annots")]
+    pub annots: Option<Vec<MaybeRef<Annot>>>,
 }
 fn inherit<'a, T: 'a, F>(mut parent: &'a PageTree, f: F) -> Result<Option<T>>
     where F: Fn(&'a PageTree) -> Option<T>
@@ -283,6 +286,7 @@ impl Page {
             resources:  None,
             contents:   None,
             rotate:     0,
+            annots:     None,
         }
     }
     pub fn media_box(&self) -> Result<Rect> {
@@ -811,6 +815,53 @@ pub struct FieldDictionary {
     
     #[pdf(key="AA")]
     pub actions: Option<Dictionary>,
+}
+
+// See PDF specification page 381,
+//    https://opensource.adobe.com/dc-acrobat-sdk-docs/standards/pdfstandards/pdf/PDF32000_2008.pdf
+#[derive(Object, ObjectWrite, Debug, DataSize)]
+pub struct Annot {
+    #[pdf(key="Subtype")]
+    pub subtype: Name,
+
+    #[pdf(key="Rect")]
+    pub rect: Rect,
+
+    #[pdf(key="Contents")]
+    pub contents: Option<PdfString>,
+
+    #[pdf(key="P")]
+    pub page: Option<Dictionary>,
+
+    #[pdf(key="NM")]
+    pub annotation_name: Option<PdfString>,
+
+    #[pdf(key="M")]
+    pub last_modified: Option<PdfString>, // should be a date formatted as a string
+
+    #[pdf(key="F")]
+    pub flags: Option<u32>,
+
+    #[pdf(key="AP")]
+    pub appearance: Option<Dictionary>,
+
+    #[pdf(key="AS")]
+    pub appearance_state: Option<Name>,
+
+    #[pdf(key="Border")]
+    pub border: Option<Vec<u32>>,
+
+    #[pdf(key="C")]
+    pub color: Option<Vec<f32>>,
+
+    #[pdf(key="StructParent")]
+    pub struct_parent: Option<u32>,
+
+    #[pdf(key="OC")]
+    pub optional_content: Option<Dictionary>,
+
+    #[pdf(key="A")]
+    pub ahref: Option<Dictionary>,
 }
 
 #[derive(Debug, DataSize)]


### PR DESCRIPTION
This draft contribution adds support for PDF annotations. 

The support is incomplete. Annotations are PDF dictionaries with different values for /Subtype (Text, Ink, Pop-up, Line, etc.). A number of keys, included in this patch, are common to all annotation subtypes (some of them optional). In addition, each annotation subtype has a number of additional keys that are specific to that subtype (for instance, a Text annotation may have a "Name" entry, a "State" entry, etc.). 

These could be added as extra optional fields in the Annot struct, but (1) they are semantically invalid for other annotation subtypes and (2) they are quite numerous. 

Any suggestions? (For example, the lopdf crate uses dictionaries internally, which avoids this type of problem.)