### PR TITLE
Fix bug where compression filters are passed through as image filters

### DIFF
--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -567,7 +567,7 @@ impl ImageXObject {
                     [StreamFilter::DCTDecode(_)] |
                     [StreamFilter::CCITTFaxDecode(_)] |
                     [StreamFilter::JPXDecode] |
-                    [StreamFilter::JBIG2Decode] => Ok((data, Some(&filters[0]))),
+                    [StreamFilter::JBIG2Decode] => Ok((data, Some(&image_filters[0]))),
                     _ => bail!("??? filters={:?}", image_filters)
                 }
             }


### PR DESCRIPTION
Came across this bug where the original filters slice is passed through instead of the `image_filters`.