### PR TITLE
Fix parsing of NameTree<Primitive> type by optionally dereferencing.

### DIFF
--- a/pdf/src/content.rs
+++ b/pdf/src/content.rs
@@ -885,7 +885,7 @@ impl Object for Matrix {
 impl ObjectWrite for Matrix {
     fn to_primitive(&self, update: &mut impl Updater) -> Result<Primitive> {
         let Matrix { a, b, c, d, e, f } = *self;
-        Primitive::array::<f32, _, _, _>([a, b, c, d, e, f].into_iter(), update)
+        Primitive::array::<f32, _, _, _>([a, b, c, d, e, f].iter(), update)
     }
 }
 #[cfg(feature = "euclid")]

--- a/pdf/src/error.rs
+++ b/pdf/src/error.rs
@@ -94,7 +94,7 @@ pub enum PdfError {
     #[snafu(display("Tried to dereference non-existing object nr {}.", obj_nr))]
     NullRef {obj_nr: u64},
 
-    #[snafu(display("Expected primitive {}, found primive {} instead.", expected, found))]
+    #[snafu(display("Expected primitive {}, found primitive {} instead.", expected, found))]
     UnexpectedPrimitive {expected: &'static str, found: &'static str},
     /*
     WrongObjectType {expected: &'static str, found: &'static str} {

--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -409,7 +409,7 @@ impl ObjectWrite for Pattern {
         match self {
             Pattern::Dict(ref d) => d.to_primitive(update),
             Pattern::Stream(ref d, ref ops) => {
-                let data = serialize_ops(&ops)?;
+                let data = serialize_ops(ops)?;
                 let stream = Stream::new_with_filters(d.clone(), data, vec![]);
                 stream.to_primitive(update)
             }
@@ -909,7 +909,7 @@ impl<T: Object> Object for NameTree<T> {
                 let names = names.resolve(resolve)?.into_array()?;
                 let mut new_names = Vec::new();
                 for pair in names.chunks(2) {
-                    let name = pair[0].clone().into_string()?;
+                    let name = pair[0].clone().resolve(resolve)?.into_string()?;
                     let value = t!(T::from_primitive(pair[1].clone(), resolve));
                     new_names.push((name, value));
                 }
@@ -985,10 +985,10 @@ impl Dest {
                     ref p => return Err(PdfError::UnexpectedPrimitive { expected: "Number | Integer | Null", found: p.get_debug_name() }),
                 },
                 zoom: match array.get(4) {
-                    Some(&Primitive::Null) => 0.0,
+                    Some(Primitive::Null) => 0.0,
                     Some(&Primitive::Integer(n)) => n as f32,
                     Some(&Primitive::Number(f)) => f,
-                    Some(ref p) => return Err(PdfError::UnexpectedPrimitive { expected: "Number | Integer | Null", found: p.get_debug_name() }),
+                    Some(p) => return Err(PdfError::UnexpectedPrimitive { expected: "Number | Integer | Null", found: p.get_debug_name() }),
                     None => 0.0,
                 },
             },


### PR DESCRIPTION
Resolves an error encountered parsing PDF file sample01.pdf from
https://github.com/sambitdash/PDFTest/tree/master/DigSig

Try { file: "pdf/src/file.rs", line: 324, column: 23, context: Context([]), source: FromPrimitive { typ: "RcRef < Catalog >", field: "root", source: Shared { source: FromPrimitive { typ: "Option < MaybeRef < NameDictionary > >", field: "names", source: Shared { source: FromPrimitive { typ: "Option < NameTree < Primitive > >", field: "ids", source: UnexpectedPrimitive { expected: "String", found: "Reference" } } } } } } }