### PR TITLE
Add support for StreamFilter::DCTDecode

### DIFF
--- a/pdf/src/enc.rs
+++ b/pdf/src/enc.rs
@@ -425,6 +425,7 @@ pub fn decode(data: &[u8], filter: &StreamFilter) -> Result<Vec<u8>> {
         StreamFilter::LZWDecode(ref params) => lzw_decode(data, params),
         StreamFilter::FlateDecode(ref params) => flate_decode(data, params),
         StreamFilter::RunLengthDecode => run_length_decode(data),
+        StreamFilter::DCTDecode(ref params) => dct_decode(data, params),
 
         _ => bail!("unimplemented {filter:?}"),
     }


### PR DESCRIPTION
I have a PDF with images using the DCTDecode filter for their masks, which would previously cause errors when attempting to extract them (using code like that in `pdf_render`). It seems like this might have just been a minor point that was missed in previous work because after this one-line change to add a match clause, I can successfully extract images and their masks from that PDF and have verified that they seem to be read as expected.