### PR TITLE
fix panics on opening encrypted pdfs

### DIFF
--- a/pdf/src/file.rs
+++ b/pdf/src/file.rs
@@ -72,7 +72,7 @@ impl<B: Backend> Storage<B> {
 
         let mut data = Vec::from(data);
         if let Some(ref decoder) = self.decoder {
-            t!(decoder.decrypt(id, &mut data));
+            data = Vec::from(t!(decoder.decrypt(id, &mut data)));
         }
         for filter in filters {
             data = t!(decode(&data, filter), filter);


### PR DESCRIPTION
This pull request fixes the following:

* When opening encrypted pdfs with 128 bit keys, pdf-rs paniced because of missing range checks.

* The encryption was not properly applied to streams which lead to panics when LZW Decompress was applied to encrypted data.