### PR TITLE
Let utf16be_to_string_lossy return a String directly

### DIFF
--- a/pdf/examples/names.rs
+++ b/pdf/examples/names.rs
@@ -61,7 +61,7 @@ fn main() {
     let mut dests_cb = |key: &PdfString, val: &Option<Dest>| {
         //println!("{:?} {:?}", key, val);
         if let Some(Dest { page: Some(page), ..}) = val {
-            pages_map.insert(key.to_string_lossy().unwrap(), page.get_inner());
+            pages_map.insert(key.to_string_lossy(), page.get_inner());
         }
 
         count += 1;

--- a/pdf/examples/read.rs
+++ b/pdf/examples/read.rs
@@ -84,12 +84,7 @@ fn main() -> Result<(), PdfError> {
         for field in forms.fields.iter() {
             print!("  {:?} = ", field.name);
             match field.value {
-                Primitive::String(ref s) => {
-                    match s.to_string_lossy() {
-                        Ok(s) => println!("{:?}", s),
-                        Err(_) => println!("{:?}", s),
-                    }
-                }
+                Primitive::String(ref s) => println!("{}", s.to_string_lossy()),
                 Primitive::Integer(i) => println!("{}", i),
                 Primitive::Name(ref s) => println!("{}", s),
                 ref p => println!("{:?}", p),

--- a/pdf/src/font.rs
+++ b/pdf/src/font.rs
@@ -477,10 +477,10 @@ pub fn utf16be_to_char(
     char::decode_utf16(data.chunks(2).map(|w| u16::from_be_bytes([w[0], w[1]])))
 }
 /// converts UTF16-BE to a string replacing illegal/unknown characters
-pub fn utf16be_to_string_lossy(data: &[u8]) -> pdf::error::Result<String> {
-    Ok(utf16be_to_char(data)
+pub fn utf16be_to_string_lossy(data: &[u8]) -> String {
+    utf16be_to_char(data)
         .map(|r| r.unwrap_or(std::char::REPLACEMENT_CHARACTER))
-        .collect())
+        .collect()
 }
 /// converts UTF16-BE to a string errors out in illegal/unknonw characters
 pub fn utf16be_to_string(data: &[u8]) -> pdf::error::Result<SmallString> {
@@ -624,6 +624,6 @@ mod tests {
             assert_eq!(r.to_string(), "UTF16 decode error");
         }
         assert_eq!(utf16be_to_string(&v[..8]).unwrap(), String::from("𝄞mu"));
-        assert_eq!(utf16be_to_string_lossy(&v).unwrap(), lossy);
+        assert_eq!(utf16be_to_string_lossy(&v), lossy);
     }
 }


### PR DESCRIPTION
Function utf16be_tu_string_lossy always returns an Ok(..) result, as its name suggests. Therefore wrapping in a Result<_> is unnecessary. Bubbles up to PdfString::to_string_lossy.