### PR TITLE
Don't write to /tmp/data

### DIFF
--- a/pdf/src/enc.rs
+++ b/pdf/src/enc.rs
@@ -260,7 +260,6 @@ pub fn flate_decode(data: &[u8], params: &LZWFlateParams) -> Result<Vec<u8>> {
     let decoded = match inflate_bytes_zlib(data) {
         Ok(data) => data,
         Err(_) => {
-            std::fs::write("/tmp/data", data).unwrap();
             info!("invalid zlib header. trying without");
             inflate_bytes(data)?
         }


### PR DESCRIPTION
In an error handling branch some data is written to /tmp/data (presumably for debugging). This causes a write error on windows, obscuring the actual error. This could be done using the `tempfile` crate to be cross platform but it's probably better just to remove the call as it's not used by the library itself.