### PR TITLE
Make globalcache feature optional

### DIFF
--- a/pdf/Cargo.toml
+++ b/pdf/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 description = "PDF reader"
 
 [features]
+default = ["globalcache"]
 mmap = ["memmap2"]
 dump = ["tempfile"]
 threads = ["jpeg-decoder/default"]
@@ -38,7 +39,7 @@ euclid = { version = "0.22.7", optional = true }
 bitflags = "1.3"
 istring = { version = "0.3.3", features = ["std", "size"] }
 datasize = "0.2.13"
-globalcache = { version = "0.2", features = ["sync"] }
+globalcache = { version = "0.2", features = ["sync"], optional = true }
 
 [dev-dependencies]
 glob = "0.3.0"

--- a/pdf/src/any.rs
+++ b/pdf/src/any.rs
@@ -1,6 +1,7 @@
 use std::any::TypeId;
 use std::rc::Rc;
 use std::sync::Arc;
+#[cfg(feature = "globalcache")]
 use globalcache::ValueSize;
 use datasize::DataSize;
 use crate::object::{Object};
@@ -86,6 +87,7 @@ impl<T: AnyObject + Sync + Send + 'static> From<Arc<T>> for AnySync {
         AnySync::new(t)
     }
 }
+#[cfg(feature = "globalcache")]
 impl ValueSize for AnySync {
     fn size(&self) -> usize {
         self.0.size()

--- a/pdf/src/error.rs
+++ b/pdf/src/error.rs
@@ -169,6 +169,7 @@ impl PdfError {
     }
 }
 datasize::non_dynamic_const_heap_size!(PdfError, 0);
+#[cfg(feature = "globalcache")]
 impl globalcache::ValueSize for PdfError {
     #[inline]
     fn size(&self) -> usize {


### PR DESCRIPTION
Currently this create doesn't work with wasm because of globalcache usage.
In order to fix #169 I made this feature optional.