### PR TITLE
Support stream types in creating encoding

### DIFF
--- a/pdf/src/encoding.rs
+++ b/pdf/src/encoding.rs
@@ -19,7 +19,7 @@ pub enum BaseEncoding {
     MacRomanEncoding,
     WinAnsiEncoding,
     MacExpertEncoding,
-    #[pdf(name="Identity-H")]
+    #[pdf(name = "Identity-H")]
     IdentityH,
     None,
 
@@ -31,8 +31,8 @@ impl Object for Encoding {
         match p {
             name @ Primitive::Name(_) => { 
                 Ok(Encoding {
-                    base: BaseEncoding::from_primitive(name, resolve)?,
-                    differences: HashMap::new(),
+                base: BaseEncoding::from_primitive(name, resolve)?,
+                differences: HashMap::new(),
                 })
             }
             Primitive::Dictionary(mut dict) => {
@@ -51,19 +51,20 @@ impl Object for Encoding {
                             Primitive::Name(name) => {
                                 differences.insert(gid, name);
                                 gid += 1;
-                            },
-                            _ => panic!()
+                            }
+                            _ => panic!("Unknown part primitive in dictionary: {:?}", part),
                         }
                     }
                 }
                 Ok(Encoding { base, differences })
             }
             Primitive::Reference(r) => Self::from_primitive(resolve.resolve(r)?, resolve),
-            _ => panic!()
+            Primitive::Stream(s) => Self::from_primitive(Primitive::Dictionary(s.info), resolve),
+            _ => panic!("Unknown element: {:?}", p),
         }
     }
 }
-impl Encoding { 
+impl Encoding {
     pub fn standard() -> Encoding {
         Encoding {
             base: BaseEncoding::StandardEncoding,


### PR DESCRIPTION
USGS GeoTopo PDFs stash font data in Streams.  Here we patch the stream info dictionary into the processing feed instead of panic'ing.