### PR TITLE
Improve the badges in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# pdf-rs [![test](https://github.com/pdf-rs/pdf/actions/workflows/test.yml/badge.svg)](https://github.com/pdf-rs/pdf/actions/workflows/test.yml) [![clippy&fmt](https://github.com/pdf-rs/pdf/actions/workflows/lint.yml/badge.svg)](https://github.com/pdf-rs/pdf/actions/workflows/lint.yml)
+# pdf-rs [![test_badge]][test_action] [![lint_badge]][lint_action] [![Latest version]][crates.io]
+
+[test_badge]: https://github.com/pdf-rs/pdf/actions/workflows/test.yml/badge.svg
+[test_action]: https://github.com/pdf-rs/pdf/actions/workflows/test.yml
+[lint_badge]: https://github.com/pdf-rs/pdf/actions/workflows/lint.yml/badge.svg
+[lint_action]: https://github.com/pdf-rs/pdf/actions/workflows/lint.yml
+[Latest version]: https://img.shields.io/crates/v/pdf.svg
+[crates.io]: https://crates.io/crates/pdf
+
 Read, alter and write PDF files.
 
 Modifying and writing PDFs is still experimental.


### PR DESCRIPTION
I am usually most interesting in finding my way to the docs. Getting to crates.io is a good start in this journey as it has a link to the docs in it. I have copied the general format of the links from the serde readme.