### PR TITLE
fix typo in example CLI doc comments

### DIFF
--- a/examples/src/bin/add_image.rs
+++ b/examples/src/bin/add_image.rs
@@ -13,11 +13,11 @@ use image::io::Reader as ImageReader;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Input file
+    /// Input PDF file
     #[arg(short, long)]
     input: PathBuf,
 
-    /// Page number
+    /// Input image file
     #[arg(long)]
     image: PathBuf,
 


### PR DESCRIPTION
The CLI doc comments that clap also uses to generate a --help interface was wrong and undescriptive.
I've changed them so they reflect their actual use in the example program.