### PR TITLE
deconflict object::types::Rect and content::Rect

### DIFF
--- a/pdf/src/content.rs
+++ b/pdf/src/content.rs
@@ -1,17 +1,18 @@
+use datasize::DataSize;
+use istring::SmallString;
+use itertools::Itertools;
+use std::cmp::Ordering;
+use std::convert::TryFrom;
 /// PDF content streams.
 use std::fmt::{self, Display};
-use std::cmp::Ordering;
-use itertools::Itertools;
-use istring::SmallString;
-use datasize::DataSize;
 use std::sync::Arc;
 
+use crate as pdf;
+use crate::enc::StreamFilter;
 use crate::error::*;
 use crate::object::*;
-use crate::parser::{Lexer, parse_with_lexer, ParseFlags};
+use crate::parser::{parse_with_lexer, Lexer, ParseFlags};
 use crate::primitive::*;
-use crate::enc::StreamFilter;
-use crate as pdf;
 
 /// Represents a PDF content stream - a `Vec` of `Operator`s
 #[derive(Debug, Clone, DataSize)]
@@ -57,41 +58,51 @@ macro_rules! points {
         )*
     )
 }
-fn name(args: &mut impl Iterator<Item=Primitive>) -> Result<Name> {
+fn name(args: &mut impl Iterator<Item = Primitive>) -> Result<Name> {
     args.next().ok_or(PdfError::NoOpArg)?.into_name()
 }
-fn number(args: &mut impl Iterator<Item=Primitive>) -> Result<f32> {
+fn number(args: &mut impl Iterator<Item = Primitive>) -> Result<f32> {
     args.next().ok_or(PdfError::NoOpArg)?.as_number()
 }
-fn string(args: &mut impl Iterator<Item=Primitive>) -> Result<PdfString> {
+fn string(args: &mut impl Iterator<Item = Primitive>) -> Result<PdfString> {
     args.next().ok_or(PdfError::NoOpArg)?.into_string()
 }
-fn point(args: &mut impl Iterator<Item=Primitive>) -> Result<Point> {
+fn point(args: &mut impl Iterator<Item = Primitive>) -> Result<Point> {
     let x = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let y = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     Ok(Point { x, y })
 }
-fn rect(args: &mut impl Iterator<Item=Primitive>) -> Result<Rect> {
+fn rect(args: &mut impl Iterator<Item = Primitive>) -> Result<ViewRect> {
     let x = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let y = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let width = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let height = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
-    Ok(Rect { x, y, width, height })
+    Ok(ViewRect {
+        x,
+        y,
+        width,
+        height,
+    })
 }
-fn rgb(args: &mut impl Iterator<Item=Primitive>) -> Result<Rgb> {
+fn rgb(args: &mut impl Iterator<Item = Primitive>) -> Result<Rgb> {
     let red = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let green = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let blue = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     Ok(Rgb { red, green, blue })
 }
-fn cmyk(args: &mut impl Iterator<Item=Primitive>) -> Result<Cmyk> {
+fn cmyk(args: &mut impl Iterator<Item = Primitive>) -> Result<Cmyk> {
     let cyan = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let magenta = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let yellow = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let key = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
-    Ok(Cmyk { cyan, magenta, yellow, key })
+    Ok(Cmyk {
+        cyan,
+        magenta,
+        yellow,
+        key,
+    })
 }
-fn matrix(args: &mut impl Iterator<Item=Primitive>) -> Result<Matrix> {
+fn matrix(args: &mut impl Iterator<Item = Primitive>) -> Result<Matrix> {
     Ok(Matrix {
         a: number(args)?,
         b: number(args)?,
@@ -101,11 +112,11 @@ fn matrix(args: &mut impl Iterator<Item=Primitive>) -> Result<Matrix> {
         f: number(args)?,
     })
 }
-fn array(args: &mut impl Iterator<Item=Primitive>) -> Result<Vec<Primitive>> {
+fn array(args: &mut impl Iterator<Item = Primitive>) -> Result<Vec<Primitive>> {
     match args.next() {
         Some(Primitive::Array(arr)) => Ok(arr),
         None => Ok(vec![]),
-        _ => Err(PdfError::NoOpArg)
+        _ => Err(PdfError::NoOpArg),
     }
 }
 
@@ -120,8 +131,10 @@ fn expand_abbr_name(name: SmallString, alt: &[(&str, &str)]) -> SmallString {
 fn expand_abbr(p: Primitive, alt: &[(&str, &str)]) -> Primitive {
     match p {
         Primitive::Name(name) => Primitive::Name(expand_abbr_name(name, alt)),
-        Primitive::Array(items) => Primitive::Array(items.into_iter().map(|p| expand_abbr(p, alt)).collect()),
-        p => p
+        Primitive::Array(items) => {
+            Primitive::Array(items.into_iter().map(|p| expand_abbr(p, alt)).collect())
+        }
+        p => p,
     }
 }
 
@@ -137,19 +150,22 @@ fn inline_image(lexer: &mut Lexer, resolve: &impl Resolve) -> Result<Arc<ImageXO
                 lexer.set_pos(backup_pos);
                 break;
             }
-            Ok(_) => bail!("invalid key type")
+            Ok(_) => bail!("invalid key type"),
         };
-        let key = expand_abbr_name(key, &[
-            ("BPC", "BitsPerComponent"),
-            ("CS", "ColorSpace"),
-            ("D", "Decode"),
-            ("DP", "DecodeParms"),
-            ("F", "Filter"),
-            ("H", "Height"),
-            ("IM", "ImageMask"),
-            ("I", "Interpolate"),
-            ("W", "Width"),
-        ]);
+        let key = expand_abbr_name(
+            key,
+            &[
+                ("BPC", "BitsPerComponent"),
+                ("CS", "ColorSpace"),
+                ("D", "Decode"),
+                ("DP", "DecodeParms"),
+                ("F", "Filter"),
+                ("H", "Height"),
+                ("IM", "ImageMask"),
+                ("I", "Interpolate"),
+                ("W", "Width"),
+            ],
+        );
         let val = parse_with_lexer(lexer, &NoResolve, ParseFlags::ANY)?;
         dict.insert(key, val);
     }
@@ -159,45 +175,87 @@ fn inline_image(lexer: &mut Lexer, resolve: &impl Resolve) -> Result<Arc<ImageXO
     // find the end before try parsing.
     if lexer.seek_substr("\nEI").is_none() {
         bail!("inline image exceeds expected data range");
-    }    
+    }
     let data_end = lexer.get_pos() - 3;
 
     // ugh
-    let bits_per_component = dict.get("BitsPerComponent").map(|p| p.as_integer()).transpose()?;
-    let color_space = dict.get("ColorSpace").map(|p| ColorSpace::from_primitive(expand_abbr(p.clone(), 
-        &[
-            ("G", "DeviceGray"),
-            ("RGB", "DeviceRGB"),
-            ("CMYK", "DeviceCMYK"),
-            ("I", "Indexed")
-        ]
-    ), resolve)).transpose()?;
-    let decode = dict.get("Decode").map(|p| Object::from_primitive(p.clone(), resolve)).transpose()?;
-    let decode_parms = dict.get("DecodeParms").map(|p| p.clone().resolve(resolve)?.into_dictionary()).transpose()?.unwrap_or_default();
-    let filter = dict.remove("Filter").map(|p| expand_abbr(p,
-        &[
-            ("AHx", "ASCIIHexDecode"),
-            ("A85", "ASCII85Decode"),
-            ("LZW", "LZWDecode"),
-            ("Fl", "FlateDecode"),
-            ("RL", "RunLengthDecode"),
-            ("CCF", "CCITTFaxDecode"),
-            ("DCT", "DCTDecode"),
-        ]
-    ));
+    let bits_per_component = dict
+        .get("BitsPerComponent")
+        .map(|p| p.as_integer())
+        .transpose()?;
+    let color_space = dict
+        .get("ColorSpace")
+        .map(|p| {
+            ColorSpace::from_primitive(
+                expand_abbr(
+                    p.clone(),
+                    &[
+                        ("G", "DeviceGray"),
+                        ("RGB", "DeviceRGB"),
+                        ("CMYK", "DeviceCMYK"),
+                        ("I", "Indexed"),
+                    ],
+                ),
+                resolve,
+            )
+        })
+        .transpose()?;
+    let decode = dict
+        .get("Decode")
+        .map(|p| Object::from_primitive(p.clone(), resolve))
+        .transpose()?;
+    let decode_parms = dict
+        .get("DecodeParms")
+        .map(|p| p.clone().resolve(resolve)?.into_dictionary())
+        .transpose()?
+        .unwrap_or_default();
+    let filter = dict.remove("Filter").map(|p| {
+        expand_abbr(
+            p,
+            &[
+                ("AHx", "ASCIIHexDecode"),
+                ("A85", "ASCII85Decode"),
+                ("LZW", "LZWDecode"),
+                ("Fl", "FlateDecode"),
+                ("RL", "RunLengthDecode"),
+                ("CCF", "CCITTFaxDecode"),
+                ("DCT", "DCTDecode"),
+            ],
+        )
+    });
     let filters = match filter {
-        Some(Primitive::Array(parts)) => parts.into_iter()
-            .map(|p| p.as_name().and_then(|kind| StreamFilter::from_kind_and_params(kind, decode_parms.clone(), resolve)))
+        Some(Primitive::Array(parts)) => parts
+            .into_iter()
+            .map(|p| {
+                p.as_name().and_then(|kind| {
+                    StreamFilter::from_kind_and_params(kind, decode_parms.clone(), resolve)
+                })
+            })
             .collect::<Result<_>>()?,
-        Some(Primitive::Name(kind)) => vec![StreamFilter::from_kind_and_params(&kind, decode_parms, resolve)?],
+        Some(Primitive::Name(kind)) => vec![StreamFilter::from_kind_and_params(
+            &kind,
+            decode_parms,
+            resolve,
+        )?],
         None => vec![],
-        _ => bail!("invalid filter")
+        _ => bail!("invalid filter"),
     };
-    
+
     let height = dict.require("InlineImage", "Height")?.as_u32()?;
-    let image_mask = dict.get("ImageMask").map(|p| p.as_bool()).transpose()?.unwrap_or(false);
-    let intent = dict.remove("Intent").map(|p| RenderingIntent::from_primitive(p, &NoResolve)).transpose()?;
-    let interpolate = dict.get("Interpolate").map(|p| p.as_bool()).transpose()?.unwrap_or(false);
+    let image_mask = dict
+        .get("ImageMask")
+        .map(|p| p.as_bool())
+        .transpose()?
+        .unwrap_or(false);
+    let intent = dict
+        .remove("Intent")
+        .map(|p| RenderingIntent::from_primitive(p, &NoResolve))
+        .transpose()?;
+    let interpolate = dict
+        .get("Interpolate")
+        .map(|p| p.as_bool())
+        .transpose()?
+        .unwrap_or(false);
     let width = dict.require("InlineImage", "Width")?.as_u32()?;
 
     let image_dict = ImageDict {
@@ -216,22 +274,24 @@ fn inline_image(lexer: &mut Lexer, resolve: &impl Resolve) -> Result<Arc<ImageXO
         other: dict,
     };
 
-    let data = lexer.new_substr(data_start .. data_end).to_vec();
+    let data = lexer.new_substr(data_start..data_end).to_vec();
 
-    Ok(Arc::new(ImageXObject { inner: Stream::from_compressed(image_dict, data, filters) }))
+    Ok(Arc::new(ImageXObject {
+        inner: Stream::from_compressed(image_dict, data, filters),
+    }))
 }
 
 struct OpBuilder {
     last: Point,
     compability_section: bool,
-    ops: Vec<Op>
+    ops: Vec<Op>,
 }
 impl OpBuilder {
     fn new() -> Self {
         OpBuilder {
             last: Point { x: 0., y: 0. },
             compability_section: false,
-            ops: Vec::new()
+            ops: Vec::new(),
         }
     }
     fn parse(&mut self, data: &[u8], resolve: &impl Resolve) -> Result<()> {
@@ -255,10 +315,10 @@ impl OpBuilder {
                     let op = t!(lexer.next());
                     let operator = t!(op.as_str(), op);
                     match self.add(operator, buffer.drain(..), &mut lexer, resolve) {
-                        Ok(()) => {},
+                        Ok(()) => {}
                         Err(e) if resolve.options().allow_invalid_ops => {
                             warn!("OP Err: {:?}", e);
-                        },
+                        }
                         Err(e) => return Err(e),
                     }
                 }
@@ -266,162 +326,208 @@ impl OpBuilder {
             match lexer.get_pos().cmp(&data.len()) {
                 Ordering::Greater => err!(PdfError::ContentReadPastBoundary),
                 Ordering::Less => (),
-                Ordering::Equal => break
+                Ordering::Equal => break,
             }
         }
         Ok(())
     }
-    fn add(&mut self, op: &str, mut args: impl Iterator<Item=Primitive>, lexer: &mut Lexer, resolve: &impl Resolve) -> Result<()> {
+    fn add(
+        &mut self,
+        op: &str,
+        mut args: impl Iterator<Item = Primitive>,
+        lexer: &mut Lexer,
+        resolve: &impl Resolve,
+    ) -> Result<()> {
         use Winding::*;
 
         let ops = &mut self.ops;
         let mut push = move |op| ops.push(op);
 
         match op {
-            "b"   => {
+            "b" => {
                 push(Op::Close);
                 push(Op::FillAndStroke { winding: NonZero });
-            },
-            "B"   => push(Op::FillAndStroke { winding: NonZero }),
-            "b*"  => {
+            }
+            "B" => push(Op::FillAndStroke { winding: NonZero }),
+            "b*" => {
                 push(Op::Close);
                 push(Op::FillAndStroke { winding: EvenOdd });
             }
-            "B*"  => push(Op::FillAndStroke { winding: EvenOdd }),
+            "B*" => push(Op::FillAndStroke { winding: EvenOdd }),
             "BDC" => push(Op::BeginMarkedContent {
                 tag: name(&mut args)?,
-                properties: Some(args.next().ok_or(PdfError::NoOpArg)?)
+                properties: Some(args.next().ok_or(PdfError::NoOpArg)?),
             }),
-            "BI"  => push(Op::InlineImage { image: inline_image(lexer, resolve)? }),
+            "BI" => push(Op::InlineImage {
+                image: inline_image(lexer, resolve)?,
+            }),
             "BMC" => push(Op::BeginMarkedContent {
                 tag: name(&mut args)?,
-                properties: None
+                properties: None,
             }),
-            "BT"  => push(Op::BeginText),
-            "BX"  => self.compability_section = true,
-            "c"   => {
+            "BT" => push(Op::BeginText),
+            "BX" => self.compability_section = true,
+            "c" => {
                 points!(args, c1, c2, p);
                 push(Op::CurveTo { c1, c2, p });
                 self.last = p;
             }
-            "cm"  => {
+            "cm" => {
                 numbers!(args, a, b, c, d, e, f);
-                push(Op::Transform { matrix: Matrix { a, b, c, d, e, f }});
+                push(Op::Transform {
+                    matrix: Matrix { a, b, c, d, e, f },
+                });
             }
-            "CS"  => {
+            "CS" => {
                 names!(args, name);
                 push(Op::StrokeColorSpace { name });
             }
-            "cs"  => {
+            "cs" => {
                 names!(args, name);
                 push(Op::FillColorSpace { name });
             }
-            "d"  => {
+            "d" => {
                 let p = args.next().ok_or(PdfError::NoOpArg)?;
-                let pattern = p.as_array()?.iter().map(|p| p.as_number()).collect::<Result<Vec<f32>, PdfError>>()?;
+                let pattern = p
+                    .as_array()?
+                    .iter()
+                    .map(|p| p.as_number())
+                    .collect::<Result<Vec<f32>, PdfError>>()?;
                 let phase = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
                 push(Op::Dash { pattern, phase });
             }
-            "d0"  => {}
-            "d1"  => {}
+            "d0" => {}
+            "d1" => {}
             "Do" | "Do0" => {
                 names!(args, name);
                 push(Op::XObject { name });
             }
-            "DP"  => push(Op::MarkedContentPoint {
+            "DP" => push(Op::MarkedContentPoint {
                 tag: name(&mut args)?,
-                properties: Some(args.next().ok_or(PdfError::NoOpArg)?)
+                properties: Some(args.next().ok_or(PdfError::NoOpArg)?),
             }),
-            "EI"  => bail!("Parse Error. Unexpected 'EI'"),
+            "EI" => bail!("Parse Error. Unexpected 'EI'"),
             "EMC" => push(Op::EndMarkedContent),
-            "ET"  => push(Op::EndText),
-            "EX"  => self.compability_section = false,
-            "f" |
-            "F"   => push(Op::Fill { winding: NonZero }),
-            "f*"  => push(Op::Fill { winding: EvenOdd }),
-            "G"   => push(Op::StrokeColor { color: Color::Gray(number(&mut args)?) }),
-            "g"   => push(Op::FillColor { color: Color::Gray(number(&mut args)?) }),
-            "gs"  => push(Op::GraphicsState { name: name(&mut args)? }),
-            "h"   => push(Op::Close),
-            "i"   => push(Op::Flatness { tolerance: number(&mut args)? }),
-            "ID"  => bail!("Parse Error. Unexpected 'ID'"),
-            "j"   => {
+            "ET" => push(Op::EndText),
+            "EX" => self.compability_section = false,
+            "f" | "F" => push(Op::Fill { winding: NonZero }),
+            "f*" => push(Op::Fill { winding: EvenOdd }),
+            "G" => push(Op::StrokeColor {
+                color: Color::Gray(number(&mut args)?),
+            }),
+            "g" => push(Op::FillColor {
+                color: Color::Gray(number(&mut args)?),
+            }),
+            "gs" => push(Op::GraphicsState {
+                name: name(&mut args)?,
+            }),
+            "h" => push(Op::Close),
+            "i" => push(Op::Flatness {
+                tolerance: number(&mut args)?,
+            }),
+            "ID" => bail!("Parse Error. Unexpected 'ID'"),
+            "j" => {
                 let n = args.next().ok_or(PdfError::NoOpArg)?.as_integer()?;
                 let join = match n {
                     0 => LineJoin::Miter,
                     1 => LineJoin::Round,
                     2 => LineJoin::Bevel,
-                    _ => bail!("invalid line join {}", n)
+                    _ => bail!("invalid line join {}", n),
                 };
                 push(Op::LineJoin { join });
             }
-            "J"   => {
+            "J" => {
                 let n = args.next().ok_or(PdfError::NoOpArg)?.as_integer()?;
                 let cap = match n {
                     0 => LineCap::Butt,
                     1 => LineCap::Round,
                     2 => LineCap::Square,
-                    _ => bail!("invalid line cap {}", n)
+                    _ => bail!("invalid line cap {}", n),
                 };
                 push(Op::LineCap { cap });
             }
-            "K"   => {
+            "K" => {
                 let color = Color::Cmyk(cmyk(&mut args)?);
                 push(Op::StrokeColor { color });
             }
-            "k"   => {
+            "k" => {
                 let color = Color::Cmyk(cmyk(&mut args)?);
                 push(Op::FillColor { color });
             }
-            "l"   => {
+            "l" => {
                 let p = point(&mut args)?;
                 push(Op::LineTo { p });
                 self.last = p;
             }
-            "m"   => {
+            "m" => {
                 let p = point(&mut args)?;
                 push(Op::MoveTo { p });
                 self.last = p;
             }
-            "M"   => push(Op::MiterLimit { limit: number(&mut args)? }),
-            "MP"  => push(Op::MarkedContentPoint { tag: name(&mut args)?, properties: None }),
-            "n"   => push(Op::EndPath),
-            "q"   => push(Op::Save),
-            "Q"   => push(Op::Restore),
-            "re"  => push(Op::Rect { rect: rect(&mut args)? }),
-            "RG"  => push(Op::StrokeColor { color: Color::Rgb(rgb(&mut args)?) }),
-            "rg"  => push(Op::FillColor { color: Color::Rgb(rgb(&mut args)?) }),
-            "ri"  => {
+            "M" => push(Op::MiterLimit {
+                limit: number(&mut args)?,
+            }),
+            "MP" => push(Op::MarkedContentPoint {
+                tag: name(&mut args)?,
+                properties: None,
+            }),
+            "n" => push(Op::EndPath),
+            "q" => push(Op::Save),
+            "Q" => push(Op::Restore),
+            "re" => push(Op::Rect {
+                rect: rect(&mut args)?,
+            }),
+            "RG" => push(Op::StrokeColor {
+                color: Color::Rgb(rgb(&mut args)?),
+            }),
+            "rg" => push(Op::FillColor {
+                color: Color::Rgb(rgb(&mut args)?),
+            }),
+            "ri" => {
                 let s = name(&mut args)?;
-                let intent = RenderingIntent::from_str(&s)
-                    .ok_or_else(|| PdfError::Other { msg: format!("invalid rendering intent {}", s) })?;
+                let intent = RenderingIntent::from_str(&s).ok_or_else(|| PdfError::Other {
+                    msg: format!("invalid rendering intent {}", s),
+                })?;
                 push(Op::RenderingIntent { intent });
-            },
-            "s"   => {
+            }
+            "s" => {
                 push(Op::Close);
                 push(Op::Stroke);
             }
-            "S"   => push(Op::Stroke),
+            "S" => push(Op::Stroke),
             "SC" | "SCN" => {
-                push(Op::StrokeColor { color: Color::Other(args.collect()) });
+                push(Op::StrokeColor {
+                    color: Color::Other(args.collect()),
+                });
             }
             "sc" | "scn" => {
-                push(Op::FillColor { color: Color::Other(args.collect()) });
+                push(Op::FillColor {
+                    color: Color::Other(args.collect()),
+                });
             }
-            "sh"  => {
-
-            }
-            "T*"  => push(Op::TextNewline),
-            "Tc"  => push(Op::CharSpacing { char_space: number(&mut args)? }),
-            "Td"  => push(Op::MoveTextPosition { translation: point(&mut args)? }),
-            "TD"  => {
+            "sh" => {}
+            "T*" => push(Op::TextNewline),
+            "Tc" => push(Op::CharSpacing {
+                char_space: number(&mut args)?,
+            }),
+            "Td" => push(Op::MoveTextPosition {
+                translation: point(&mut args)?,
+            }),
+            "TD" => {
                 let translation = point(&mut args)?;
-                push(Op::Leading { leading: -translation.y });
+                push(Op::Leading {
+                    leading: -translation.y,
+                });
                 push(Op::MoveTextPosition { translation });
             }
-            "Tf"  => push(Op::TextFont { name: name(&mut args)?, size: number(&mut args)? }),
-            "Tj"  => push(Op::TextDraw { text: string(&mut args)? }),
-            "TJ"  => {
+            "Tf" => push(Op::TextFont {
+                name: name(&mut args)?,
+                size: number(&mut args)?,
+            }),
+            "Tj" => push(Op::TextDraw {
+                text: string(&mut args)?,
+            }),
+            "TJ" => {
                 let mut result = Vec::<TextDrawAdjusted>::new();
 
                 for spacing_or_text in array(&mut args)?.into_iter() {
@@ -429,7 +535,7 @@ impl OpBuilder {
                         Primitive::Integer(i) => TextDrawAdjusted::Spacing(i as f32),
                         Primitive::Number(f) => TextDrawAdjusted::Spacing(f),
                         Primitive::String(text) => TextDrawAdjusted::Text(text),
-                        p => bail!("invalid primitive in TJ operator: {:?}", p)
+                        p => bail!("invalid primitive in TJ operator: {:?}", p),
                     };
 
                     result.push(spacing_or_text);
@@ -437,9 +543,13 @@ impl OpBuilder {
 
                 push(Op::TextDrawAdjusted { array: result })
             }
-            "TL"  => push(Op::Leading { leading: number(&mut args)? }),
-            "Tm"  => push(Op::SetTextMatrix { matrix: matrix(&mut args)? }), 
-            "Tr"  => {
+            "TL" => push(Op::Leading {
+                leading: number(&mut args)?,
+            }),
+            "Tm" => push(Op::SetTextMatrix {
+                matrix: matrix(&mut args)?,
+            }),
+            "Tr" => {
                 use TextMode::*;
 
                 let n = args.next().ok_or(PdfError::NoOpArg)?.as_integer()?;
@@ -456,35 +566,55 @@ impl OpBuilder {
                 };
                 push(Op::TextRenderMode { mode });
             }
-            "Ts"  => push(Op::TextRise { rise: number(&mut args)? }),
-            "Tw"  => push(Op::WordSpacing { word_space: number(&mut args)? }),
-            "Tz"  => push(Op::TextScaling { horiz_scale: number(&mut args)? }),
-            "v"   => {
+            "Ts" => push(Op::TextRise {
+                rise: number(&mut args)?,
+            }),
+            "Tw" => push(Op::WordSpacing {
+                word_space: number(&mut args)?,
+            }),
+            "Tz" => push(Op::TextScaling {
+                horiz_scale: number(&mut args)?,
+            }),
+            "v" => {
                 points!(args, c2, p);
-                push(Op::CurveTo { c1: self.last, c2, p });
+                push(Op::CurveTo {
+                    c1: self.last,
+                    c2,
+                    p,
+                });
                 self.last = p;
             }
-            "w"   => push(Op::LineWidth { width: number(&mut args)? }),
-            "W"   => push(Op::Clip { winding: NonZero }),
-            "W*"  => push(Op::Clip { winding: EvenOdd }),
-            "y"   => {
+            "w" => push(Op::LineWidth {
+                width: number(&mut args)?,
+            }),
+            "W" => push(Op::Clip { winding: NonZero }),
+            "W*" => push(Op::Clip { winding: EvenOdd }),
+            "y" => {
                 points!(args, c1, p);
                 push(Op::CurveTo { c1, c2: p, p });
                 self.last = p;
             }
-            "'"   => {
+            "'" => {
                 push(Op::TextNewline);
-                push(Op::TextDraw { text: string(&mut args)? });
+                push(Op::TextDraw {
+                    text: string(&mut args)?,
+                });
             }
-            "\""  => {
-                push(Op::WordSpacing { word_space: number(&mut args)? });
-                push(Op::CharSpacing { char_space: number(&mut args)? });
+            "\"" => {
+                push(Op::WordSpacing {
+                    word_space: number(&mut args)?,
+                });
+                push(Op::CharSpacing {
+                    char_space: number(&mut args)?,
+                });
                 push(Op::TextNewline);
-                push(Op::TextDraw { text: string(&mut args)? });
+                push(Op::TextDraw {
+                    text: string(&mut args)?,
+                });
             }
             o if !self.compability_section => {
                 bail!("invalid operator {}", o)
-            },
+            }
             _ => {}
         }
         Ok(())
@@ -504,7 +634,9 @@ impl Object for Content {
                     parts.push(part);
                 }
             }
-            Primitive::Reference(r) => return Self::from_primitive(t!(resolve.resolve(r)), resolve),
+            Primitive::Reference(r) => {
+                return Self::from_primitive(t!(resolve.resolve(r)), resolve)
+            }
             p => {
                 let part = t!(ContentStream::from_primitive(p, resolve));
                 parts.push(part);
@@ -534,9 +666,7 @@ impl Object for FormXObject {
     /// Convert primitive to Self
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         let stream = t!(Stream::<FormDict>::from_primitive(p, resolve));
-        Ok(FormXObject {
-            stream,
-        })
+        Ok(FormXObject { stream })
     }
 }
 impl ObjectWrite for FormXObject {
@@ -547,7 +677,7 @@ impl ObjectWrite for FormXObject {
     }
 }
 
-#[allow(clippy::float_cmp)]  // TODO
+#[allow(clippy::float_cmp)] // TODO
 pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
     use std::io::Write;
 
@@ -558,23 +688,35 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
     while ops.len() > 0 {
         let mut advance = 1;
         match ops[0] {
-            Op::BeginMarkedContent { ref tag, properties: Some(ref name) } => {
+            Op::BeginMarkedContent {
+                ref tag,
+                properties: Some(ref name),
+            } => {
                 serialize_name(tag, f)?;
                 write!(f, " ")?;
                 name.serialize(f)?;
                 writeln!(f, " BDC")?;
             }
-            Op::BeginMarkedContent { ref tag, properties: None } => {
+            Op::BeginMarkedContent {
+                ref tag,
+                properties: None,
+            } => {
                 serialize_name(tag, f)?;
                 writeln!(f, " BMC")?;
             }
-            Op::MarkedContentPoint { ref tag, properties: Some(ref name) } => {
+            Op::MarkedContentPoint {
+                ref tag,
+                properties: Some(ref name),
+            } => {
                 serialize_name(tag, f)?;
                 write!(f, " ")?;
                 name.serialize(f)?;
                 writeln!(f, " DP")?;
             }
-            Op::MarkedContentPoint { ref tag, properties: None } => {
+            Op::MarkedContentPoint {
+                ref tag,
+                properties: None,
+            } => {
                 serialize_name(tag, f)?;
                 writeln!(f, " MP")?;
             }
@@ -584,16 +726,20 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                     writeln!(f, "s")?;
                     advance += 1;
                 }
-                Some(Op::FillAndStroke { winding: Winding::NonZero }) => {
+                Some(Op::FillAndStroke {
+                    winding: Winding::NonZero,
+                }) => {
                     writeln!(f, "b")?;
                     advance += 1;
                 }
-                Some(Op::FillAndStroke { winding: Winding::EvenOdd }) => {
+                Some(Op::FillAndStroke {
+                    winding: Winding::EvenOdd,
+                }) => {
                     writeln!(f, "b*")?;
                     advance += 1;
                 }
                 _ => writeln!(f, "h")?,
-            }
+            },
             Op::MoveTo { p } => {
                 writeln!(f, "{} m", p)?;
                 current_point = Some(p);
@@ -601,7 +747,7 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
             Op::LineTo { p } => {
                 writeln!(f, "{} l", p)?;
                 current_point = Some(p);
-            },
+            }
             Op::CurveTo { c1, c2, p } => {
                 if Some(c1) == current_point {
                     writeln!(f, "{} {} v", c2, p)?;
@@ -611,25 +757,39 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                     writeln!(f, "{} {} {} c", c1, c2, p)?;
                 }
                 current_point = Some(p);
-            },
+            }
             Op::Rect { rect } => writeln!(f, "{} re", rect)?,
             Op::EndPath => writeln!(f, "n")?,
             Op::Stroke => writeln!(f, "S")?,
-            Op::FillAndStroke { winding: Winding::NonZero } => writeln!(f, "B")?,
-            Op::FillAndStroke { winding: Winding::EvenOdd } => writeln!(f, "B*")?,
-            Op::Fill { winding: Winding::NonZero } => writeln!(f, "f")?,
-            Op::Fill { winding: Winding::EvenOdd } => writeln!(f, "f*")?,
+            Op::FillAndStroke {
+                winding: Winding::NonZero,
+            } => writeln!(f, "B")?,
+            Op::FillAndStroke {
+                winding: Winding::EvenOdd,
+            } => writeln!(f, "B*")?,
+            Op::Fill {
+                winding: Winding::NonZero,
+            } => writeln!(f, "f")?,
+            Op::Fill {
+                winding: Winding::EvenOdd,
+            } => writeln!(f, "f*")?,
             Op::Shade { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " sh")?;
-            },
-            Op::Clip { winding: Winding::NonZero } => writeln!(f, "W")?,
-            Op::Clip { winding: Winding::EvenOdd } => writeln!(f, "W*")?,
+            }
+            Op::Clip {
+                winding: Winding::NonZero,
+            } => writeln!(f, "W")?,
+            Op::Clip {
+                winding: Winding::EvenOdd,
+            } => writeln!(f, "W*")?,
             Op::Save => writeln!(f, "q")?,
             Op::Restore => writeln!(f, "Q")?,
             Op::Transform { matrix } => writeln!(f, "{} cm", matrix)?,
             Op::LineWidth { width } => writeln!(f, "{} w", width)?,
-            Op::Dash { ref pattern, phase } => write!(f, "[{}] {} d", pattern.iter().format(" "), phase)?,
+            Op::Dash { ref pattern, phase } => {
+                write!(f, "[{}] {} d", pattern.iter().format(" "), phase)?
+            }
             Op::LineJoin { join } => writeln!(f, "{} j", join as u8)?,
             Op::LineCap { cap } => writeln!(f, "{} J", cap as u8)?,
             Op::MiterLimit { limit } => writeln!(f, "{} M", limit)?,
@@ -637,21 +797,37 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
             Op::GraphicsState { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " gs")?;
-            },
-            Op::StrokeColor { color: Color::Gray(g) } => writeln!(f, "{} G", g)?,
-            Op::StrokeColor { color: Color::Rgb(rgb) } => writeln!(f, "{} RG", rgb)?,
-            Op::StrokeColor { color: Color::Cmyk(cmyk) } => writeln!(f, "{} K", cmyk)?,
-            Op::StrokeColor { color: Color::Other(ref args) } =>  {
+            }
+            Op::StrokeColor {
+                color: Color::Gray(g),
+            } => writeln!(f, "{} G", g)?,
+            Op::StrokeColor {
+                color: Color::Rgb(rgb),
+            } => writeln!(f, "{} RG", rgb)?,
+            Op::StrokeColor {
+                color: Color::Cmyk(cmyk),
+            } => writeln!(f, "{} K", cmyk)?,
+            Op::StrokeColor {
+                color: Color::Other(ref args),
+            } => {
                 for p in args {
                     p.serialize(f)?;
                     write!(f, " ")?;
                 }
                 writeln!(f, "SCN")?;
             }
-            Op::FillColor { color: Color::Gray(g) } => writeln!(f, "{} g", g)?,
-            Op::FillColor { color: Color::Rgb(rgb) } => writeln!(f, "{} rg", rgb)?,
-            Op::FillColor { color: Color::Cmyk(cmyk) } => writeln!(f, "{} k", cmyk)?,
-            Op::FillColor { color: Color::Other(ref args) } => {
+            Op::FillColor {
+                color: Color::Gray(g),
+            } => writeln!(f, "{} g", g)?,
+            Op::FillColor {
+                color: Color::Rgb(rgb),
+            } => writeln!(f, "{} rg", rgb)?,
+            Op::FillColor {
+                color: Color::Cmyk(cmyk),
+            } => writeln!(f, "{} k", cmyk)?,
+            Op::FillColor {
+                color: Color::Other(ref args),
+            } => {
                 for p in args {
                     p.serialize(f)?;
                     write!(f, " ")?;
@@ -661,23 +837,20 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
             Op::FillColorSpace { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " cs")?;
-            },
+            }
             Op::StrokeColorSpace { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " CS")?;
-            },
+            }
 
             Op::RenderingIntent { intent } => writeln!(f, "{} ri", intent.to_str())?,
             Op::BeginText => writeln!(f, "BT")?,
             Op::EndText => writeln!(f, "ET")?,
             Op::CharSpacing { char_space } => writeln!(f, "{} Tc", char_space)?,
             Op::WordSpacing { word_space } => {
-                if let [
-                    Op::CharSpacing { char_space },
-                    Op::TextNewline,
-                    Op::TextDraw { ref text },
-                    ..
-                ] = ops[1..] {
+                if let [Op::CharSpacing { char_space }, Op::TextNewline, Op::TextDraw { ref text }, ..] =
+                    ops[1..]
+                {
                     write!(f, "{} {} ", word_space, char_space)?;
                     text.serialize(f)?;
                     writeln!(f, " \"")?;
@@ -695,14 +868,16 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                 _ => {
                     writeln!(f, "{} TL", leading)?;
                 }
-            }
+            },
             Op::TextFont { ref name, ref size } => {
                 serialize_name(name, f)?;
                 writeln!(f, " {} Tf", size)?;
-            },
+            }
             Op::TextRenderMode { mode } => writeln!(f, "{} Tr", mode as u8)?,
             Op::TextRise { rise } => writeln!(f, "{} Ts", rise)?,
-            Op::MoveTextPosition { translation } => writeln!(f, "{} {} Td", translation.x, translation.y)?,
+            Op::MoveTextPosition { translation } => {
+                writeln!(f, "{} {} Td", translation.x, translation.y)?
+            }
             Op::SetTextMatrix { matrix } => writeln!(f, "{} Tm", matrix)?,
             Op::TextNewline => {
                 if let [Op::TextDraw { ref text }, ..] = ops[1..] {
@@ -712,11 +887,11 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                 } else {
                     writeln!(f, "T*")?;
                 }
-            },
+            }
             Op::TextDraw { ref text } => {
                 text.serialize(f)?;
                 writeln!(f, " Tj")?;
-            },
+            }
             Op::TextDrawAdjusted { ref array } => {
                 write!(f, "[")?;
                 for (i, val) in array.iter().enumerate() {
@@ -729,12 +904,12 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                     }
                 }
                 writeln!(f, "] TJ")?;
-            },
+            }
             Op::InlineImage { image: _ } => unimplemented!(),
             Op::XObject { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " Do")?;
-            },
+            }
         }
         ops = &ops[advance..];
     }
@@ -745,7 +920,7 @@ impl Content {
     pub fn from_ops(operations: Vec<Op>) -> Self {
         let data = serialize_ops(&operations).unwrap();
         Content {
-            parts: vec![Stream::new((), data)]
+            parts: vec![Stream::new((), data)],
         }
     }
 }
@@ -764,7 +939,7 @@ impl ObjectWrite for Content {
 #[derive(Debug, Copy, Clone, PartialEq, DataSize)]
 pub enum Winding {
     EvenOdd,
-    NonZero
+    NonZero,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, DataSize)]
@@ -788,7 +963,7 @@ pub struct PdfSpace();
 #[repr(C, align(8))]
 pub struct Point {
     pub x: f32,
-    pub y: f32
+    pub y: f32,
 }
 impl Display for Point {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -828,40 +1003,88 @@ impl From<euclid::Vector2D<f32, PdfSpace>> for Point {
     }
 }
 
+/// ISO 32000-2:2020(E) Table 58 Pg 186 - ViewRect
+/// Path construction operators - {x y width height re}
+/// Append a rectangle to the current path as a complete
+/// subpath, with lower-left corner (x, y) and dimensions
+/// width and height in user space.
 #[derive(Debug, Copy, Clone, PartialEq, DataSize)]
 #[repr(C, align(8))]
-pub struct Rect {
+pub struct ViewRect {
     pub x: f32,
     pub y: f32,
     pub width: f32,
     pub height: f32,
 }
-impl Display for Rect {
+impl Display for ViewRect {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {} {} {}", self.x, self.y, self.width, self.height)
     }
 }
+impl From<crate::object::Rectangle> for ViewRect {
+    fn from(value: crate::object::Rectangle) -> Self {
+        let x = value.left;
+        let y = value.bottom;
+        let width = value.right - value.left;
+        let height = value.top - value.bottom;
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+impl From<ViewRect> for crate::object::Rectangle {
+    fn from(value: ViewRect) -> Self {
+        let left = value.x;
+        let bottom = value.y;
+        let right = left + value.width;
+        let top = bottom + value.height;
+        Self {
+            top,
+            left,
+            bottom,
+            right,
+        }
+    }
+}
 #[cfg(feature = "euclid")]
-impl Into<euclid::Box2D<f32, PdfSpace>> for Rect {
+impl Into<euclid::Box2D<f32, PdfSpace>> for ViewRect {
     fn into(self) -> euclid::Box2D<f32, PdfSpace> {
-        let Rect { x, y, width, height } = self;
+        let ViewRect {
+            x,
+            y,
+            width,
+            height,
+        } = self;
 
         assert!(width > 0.0);
         assert!(height > 0.0);
 
-        euclid::Box2D::new(euclid::Point2D::new(x, y), euclid::Point2D::new(x + width, y + height))
+        euclid::Box2D::new(
+            euclid::Point2D::new(x, y),
+            euclid::Point2D::new(x + width, y + height),
+        )
     }
 }
 #[cfg(feature = "euclid")]
-impl From<euclid::Box2D<f32, PdfSpace>> for Rect {
+impl From<euclid::Box2D<f32, PdfSpace>> for ViewRect {
     fn from(from: euclid::Box2D<f32, PdfSpace>) -> Self {
-        let euclid::Box2D { min: euclid::Point2D { x, y, .. }, max: euclid::Point2D { x: x2, y: y2, .. }, .. } = from;
+        let euclid::Box2D {
+            min: euclid::Point2D { x, y, .. },
+            max: euclid::Point2D { x: x2, y: y2, .. },
+            ..
+        } = from;
 
         assert!(x < x2);
         assert!(y < y2);
 
-        Rect {
-            x, y, width: x2 - x, height: y2 - y
+        ViewRect {
+            x,
+            y,
+            width: x2 - x,
+            height: y2 - y,
         }
     }
 }
@@ -878,7 +1101,11 @@ pub struct Matrix {
 }
 impl Display for Matrix {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} {} {} {} {}", self.a, self.b, self.c, self.d, self.e, self.f)
+        write!(
+            f,
+            "{} {} {} {} {} {}",
+            self.a, self.b, self.c, self.d, self.e, self.f
+        )
     }
 }
 impl Default for Matrix {
@@ -907,7 +1134,7 @@ impl ObjectWrite for Matrix {
 #[cfg(feature = "euclid")]
 impl Into<euclid::Transform2D<f32, PdfSpace, PdfSpace>> for Matrix {
     fn into(self) -> euclid::Transform2D<f32, PdfSpace, PdfSpace> {
-        let Matrix { a, b, c, d, e, f} = self;
+        let Matrix { a, b, c, d, e, f } = self;
 
         euclid::Transform2D::new(a, b, c, d, e, f)
     }
@@ -915,11 +1142,17 @@ impl Into<euclid::Transform2D<f32, PdfSpace, PdfSpace>> for Matrix {
 #[cfg(feature = "euclid")]
 impl From<euclid::Transform2D<f32, PdfSpace, PdfSpace>> for Matrix {
     fn from(from: euclid::Transform2D<f32, PdfSpace, PdfSpace>) -> Self {
-        let euclid::Transform2D { m11: a, m12: b, m21: c, m22: d, m31: e, m32: f, .. } = from;
+        let euclid::Transform2D {
+            m11: a,
+            m12: b,
+            m21: c,
+            m22: d,
+            m31: e,
+            m32: f,
+            ..
+        } = from;
 
-        Matrix {
-            a, b, c, d, e, f
-        }
+        Matrix { a, b, c, d, e, f }
     }
 }
 
@@ -938,7 +1171,7 @@ pub enum TextMode {
     FillThenStroke,
     Invisible,
     FillAndClip,
-    StrokeAndClip
+    StrokeAndClip,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, DataSize)]
@@ -962,7 +1195,11 @@ pub struct Cmyk {
 }
 impl Display for Cmyk {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} {} {}", self.cyan, self.magenta, self.yellow, self.key)
+        write!(
+            f,
+            "{} {} {} {}",
+            self.cyan, self.magenta, self.yellow, self.key
+        )
     }
 }
 
@@ -982,145 +1219,240 @@ impl Display for TextDrawAdjusted {
 }
 
 /// Graphics Operator
-/// 
+///
 /// See PDF32000 A.2
 #[derive(Debug, Clone, DataSize)]
 pub enum Op {
     /// Begin a marked comtent sequence
-    /// 
+    ///
     /// Pairs with the following EndMarkedContent.
-    /// 
+    ///
     /// generated by operators `BMC` and `BDC`
-    BeginMarkedContent { tag: Name, properties: Option<Primitive> },
+    BeginMarkedContent {
+        tag: Name,
+        properties: Option<Primitive>,
+    },
 
     /// End a marked content sequence.
-    /// 
+    ///
     /// Pairs with the previous BeginMarkedContent.
-    /// 
+    ///
     /// generated by operator `EMC`
     EndMarkedContent,
 
     /// A marked content point.
-    /// 
+    ///
     /// generated by operators `MP` and `DP`.
-    MarkedContentPoint { tag: Name, properties: Option<Primitive> },
-
+    MarkedContentPoint {
+        tag: Name,
+        properties: Option<Primitive>,
+    },
 
     Close,
-    MoveTo { p: Point },
-    LineTo { p: Point },
-    CurveTo { c1: Point, c2: Point, p: Point },
-    Rect { rect: Rect },
+    MoveTo {
+        p: Point,
+    },
+    LineTo {
+        p: Point,
+    },
+    CurveTo {
+        c1: Point,
+        c2: Point,
+        p: Point,
+    },
+    Rect {
+        rect: ViewRect,
+    },
     EndPath,
 
     Stroke,
 
     /// Fill and Stroke operation
-    /// 
+    ///
     /// generated by operators `b`, `B`, `b*`, `B*`
     /// `close` indicates whether the path should be closed first
-    FillAndStroke { winding: Winding },
+    FillAndStroke {
+        winding: Winding,
+    },
 
-
-    Fill { winding: Winding },
+    Fill {
+        winding: Winding,
+    },
 
     /// Fill using the named shading pattern
-    /// 
+    ///
     /// operator: `sh`
-    Shade { name: Name },
+    Shade {
+        name: Name,
+    },
 
-    Clip { winding: Winding },
+    Clip {
+        winding: Winding,
+    },
 
     Save,
     Restore,
 
-    Transform { matrix: Matrix },
+    Transform {
+        matrix: Matrix,
+    },
 
-    LineWidth { width: f32 },
-    Dash { pattern: Vec<f32>, phase: f32 },
-    LineJoin { join: LineJoin },
-    LineCap { cap: LineCap },
-    MiterLimit { limit: f32 },
-    Flatness { tolerance: f32 },
+    LineWidth {
+        width: f32,
+    },
+    Dash {
+        pattern: Vec<f32>,
+        phase: f32,
+    },
+    LineJoin {
+        join: LineJoin,
+    },
+    LineCap {
+        cap: LineCap,
+    },
+    MiterLimit {
+        limit: f32,
+    },
+    Flatness {
+        tolerance: f32,
+    },
 
-    GraphicsState { name: Name },
+    GraphicsState {
+        name: Name,
+    },
 
-    StrokeColor { color: Color },
-    FillColor { color: Color },
+    StrokeColor {
+        color: Color,
+    },
+    FillColor {
+        color: Color,
+    },
 
-    FillColorSpace { name: Name },
-    StrokeColorSpace { name: Name },
+    FillColorSpace {
+        name: Name,
+    },
+    StrokeColorSpace {
+        name: Name,
+    },
 
-    RenderingIntent { intent: RenderingIntent },
+    RenderingIntent {
+        intent: RenderingIntent,
+    },
 
     BeginText,
     EndText,
 
-    CharSpacing { char_space: f32 },
-    WordSpacing { word_space: f32 },
-    TextScaling { horiz_scale: f32 },
-    Leading { leading: f32 },
-    TextFont { name: Name, size: f32 },
-    TextRenderMode { mode: TextMode },
+    CharSpacing {
+        char_space: f32,
+    },
+    WordSpacing {
+        word_space: f32,
+    },
+    TextScaling {
+        horiz_scale: f32,
+    },
+    Leading {
+        leading: f32,
+    },
+    TextFont {
+        name: Name,
+        size: f32,
+    },
+    TextRenderMode {
+        mode: TextMode,
+    },
 
     /// `Ts`
-    TextRise { rise: f32 },
+    TextRise {
+        rise: f32,
+    },
 
     /// `Td`, `TD`
-    MoveTextPosition { translation: Point },
+    MoveTextPosition {
+        translation: Point,
+    },
 
     /// `Tm`
-    SetTextMatrix { matrix: Matrix },
+    SetTextMatrix {
+        matrix: Matrix,
+    },
 
     /// `T*`
     TextNewline,
 
     /// `Tj`
-    TextDraw { text: PdfString },
+    TextDraw {
+        text: PdfString,
+    },
 
-    TextDrawAdjusted { array: Vec<TextDrawAdjusted> },
+    TextDrawAdjusted {
+        array: Vec<TextDrawAdjusted>,
+    },
 
-    XObject { name: Name },
+    XObject {
+        name: Name,
+    },
 
-    InlineImage { image: Arc<ImageXObject> },
+    InlineImage {
+        image: Arc<ImageXObject>,
+    },
 }
 
-pub fn deep_clone_op(op: &Op, cloner: &mut impl Cloner, old_resources: &Resources, resources: &mut Resources) -> Result<Op> {
+pub fn deep_clone_op(
+    op: &Op,
+    cloner: &mut impl Cloner,
+    old_resources: &Resources,
+    resources: &mut Resources,
+) -> Result<Op> {
     match *op {
         Op::GraphicsState { ref name } => {
             if !resources.graphics_states.contains_key(name) {
                 if let Some(gs) = old_resources.graphics_states.get(name) {
-                    resources.graphics_states.insert(name.clone(), gs.deep_clone(cloner)?);
+                    resources
+                        .graphics_states
+                        .insert(name.clone(), gs.deep_clone(cloner)?);
                 }
             }
             Ok(Op::GraphicsState { name: name.clone() })
         }
-        Op::MarkedContentPoint { ref tag, ref properties } => {
-            Ok(Op::MarkedContentPoint { tag: tag.clone(), properties: properties.deep_clone(cloner)? })
-        }
-        Op::BeginMarkedContent { ref tag, ref properties } => {
-            Ok(Op::BeginMarkedContent { tag: tag.clone(), properties: properties.deep_clone(cloner)? })
-        }
+        Op::MarkedContentPoint {
+            ref tag,
+            ref properties,
+        } => Ok(Op::MarkedContentPoint {
+            tag: tag.clone(),
+            properties: properties.deep_clone(cloner)?,
+        }),
+        Op::BeginMarkedContent {
+            ref tag,
+            ref properties,
+        } => Ok(Op::BeginMarkedContent {
+            tag: tag.clone(),
+            properties: properties.deep_clone(cloner)?,
+        }),
         Op::TextFont { ref name, size } => {
             if !resources.fonts.contains_key(name) {
                 if let Some(f) = old_resources.fonts.get(name) {
                     resources.fonts.insert(name.clone(), f.deep_clone(cloner)?);
                 }
             }
-            Ok(Op::TextFont { name: name.clone(), size })
+            Ok(Op::TextFont {
+                name: name.clone(),
+                size,
+            })
         }
         Op::XObject { ref name } => {
             if !resources.xobjects.contains_key(name) {
                 if let Some(xo) = old_resources.xobjects.get(name) {
-                    resources.xobjects.insert(name.clone(), xo.deep_clone(cloner)?);
+                    resources
+                        .xobjects
+                        .insert(name.clone(), xo.deep_clone(cloner)?);
                 }
             }
             Ok(Op::XObject { name: name.clone() })
         }
-        ref op => Ok(op.clone())
+        ref op => Ok(op.clone()),
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -1140,6 +1472,6 @@ Gb"0F_%"1&#XD6"#B1qiGGG^V6GZ#ZkijB5'RjB4S^5I61&$Ni:Xh=4S_9KYN;c9MUZPn/h,c]oCLUmg
 EI
 "###;
         let mut lexer = Lexer::new(data);
-        assert!(inline_image(&mut lexer, &NoResolve).is_ok()); 
+        assert!(inline_image(&mut lexer, &NoResolve).is_ok());
     }
 }


### PR DESCRIPTION
Despite the noise from the reformatting...

`content.rs` lines (1006 ..= 1051) and `object/types.rs` lines (1617 ..= 1632) contain items that have been updated...

content::Rect {x,y,width,height} and object::types::Rect {bottom,left,top,right} both existed and were being mixed causing type conflict preventing compilation. Research of the ISO 32000-2-2020 specification, as noted in the comments, suggested a conversion between them. I also took the liberty to rename them per their treatment.