### PR TITLE
deconflict object::types::Rect and content::Rect

### DIFF
--- a/pdf/examples/content.rs
+++ b/pdf/examples/content.rs
@@ -1,40 +1,44 @@
 use std::env;
 use std::path::PathBuf;
 
-
-use pdf::error::PdfError;
 use pdf::content::*;
+use pdf::error::PdfError;
 use pdf::file::FileOptions;
 
-
-
-
-use pdf::object::*;
 use pdf::build::*;
+use pdf::object::*;
 
 use pdf::primitive::PdfString;
 
 fn main() -> Result<(), PdfError> {
     let path = PathBuf::from(env::args_os().nth(1).expect("no file given"));
-    
+
     let mut builder = PdfBuilder::new(FileOptions::cached());
 
     let mut pages = Vec::new();
 
     let content = Content::from_ops(vec![
-        Op::MoveTo { p: Point { x: 100., y: 100. } },
-        Op::LineTo { p: Point { x: 100., y: 200. } },
-        Op::LineTo { p: Point { x: 200., y: 200. } },
-        Op::LineTo { p: Point { x: 200., y: 100. } },
+        Op::MoveTo {
+            p: Point { x: 100., y: 100. },
+        },
+        Op::LineTo {
+            p: Point { x: 100., y: 200. },
+        },
+        Op::LineTo {
+            p: Point { x: 200., y: 200. },
+        },
+        Op::LineTo {
+            p: Point { x: 200., y: 100. },
+        },
         Op::Close,
         Op::Stroke,
     ]);
     let mut new_page = PageBuilder::from_content(content, &NoResolve)?;
-    new_page.media_box = Some(pdf::object::Rect {
+    new_page.media_box = Some(pdf::object::Rectangle {
         left: 0.0,
         top: 0.0,
         bottom: 400.0,
-        right: 400.0
+        right: 400.0,
     });
     let resources = Resources::default();
 
@@ -44,7 +48,7 @@ fn main() -> Result<(), PdfError> {
         subtype: pdf::font::FontType::TrueType,
         data: FontData::TrueType(TFont {
             base_font: None,
-            
+
         })
     }
     resources.fonts.insert("f1", font);
@@ -52,12 +56,12 @@ fn main() -> Result<(), PdfError> {
 
     new_page.resources = resources;
     pages.push(new_page);
-    
+
     let catalog = CatalogBuilder::from_pages(pages);
-    
+
     let mut info = InfoDict::default();
     info.title = Some(PdfString::from("test"));
-    
+
     let data = builder.info(info).build(catalog)?;
 
     std::fs::write(path, data)?;

--- a/pdf/examples/other_page_content.rs
+++ b/pdf/examples/other_page_content.rs
@@ -1,4 +1,4 @@
-use pdf::content::Rect;
+use pdf::content::ViewRect;
 use pdf::error::PdfError;
 use pdf::file::FileOptions;
 use pdf::object::Resolve;
@@ -47,8 +47,8 @@ fn main() -> Result<(), PdfError> {
 fn annotation_strikethrough(
     other_dict: &Dictionary,
     resolver: &impl Resolve,
-) -> Result<Vec<(String, Vec<pdf::content::Rect>)>, PdfError> {
-    let mut strikethroughs: Vec<(String, Vec<pdf::content::Rect>)> = Vec::new();
+) -> Result<Vec<(String, Vec<pdf::content::ViewRect>)>, PdfError> {
+    let mut strikethroughs: Vec<(String, Vec<pdf::content::ViewRect>)> = Vec::new();
 
     if !other_dict.is_empty() {
         let annotations = other_dict.get("Annots".into());
@@ -56,7 +56,7 @@ fn annotation_strikethrough(
             let annotations_resolved = annotations.clone().resolve(resolver)?;
             let annotations_array = annotations_resolved.into_array()?;
             for annotation in annotations_array.iter() {
-                let mut paths: Vec<pdf::content::Rect> = Vec::new();
+                let mut paths: Vec<pdf::content::ViewRect> = Vec::new();
                 let annotation_resolved = annotation.clone().resolve(resolver)?;
                 let annotation_dict = annotation_resolved.into_dictionary()?;
 
@@ -88,7 +88,7 @@ fn annotation_strikethrough(
                                         quad_points.push(number);
                                     }
                                     if quad_points.len() == 8 {
-                                        paths.push(Rect {
+                                        paths.push(ViewRect {
                                             x: quad_points[0],
                                             y: quad_points[1],
                                             width: quad_points[2] - quad_points[0],

--- a/pdf/src/content.rs
+++ b/pdf/src/content.rs
@@ -1,17 +1,18 @@
+use datasize::DataSize;
+use istring::SmallString;
+use itertools::Itertools;
+use std::cmp::Ordering;
+use std::convert::TryFrom;
 /// PDF content streams.
 use std::fmt::{self, Display};
-use std::cmp::Ordering;
-use itertools::Itertools;
-use istring::SmallString;
-use datasize::DataSize;
 use std::sync::Arc;
 
+use crate as pdf;
+use crate::enc::StreamFilter;
 use crate::error::*;
 use crate::object::*;
-use crate::parser::{Lexer, parse_with_lexer, ParseFlags};
+use crate::parser::{parse_with_lexer, Lexer, ParseFlags};
 use crate::primitive::*;
-use crate::enc::StreamFilter;
-use crate as pdf;
 
 /// Represents a PDF content stream - a `Vec` of `Operator`s
 #[derive(Debug, Clone, DataSize)]
@@ -57,41 +58,51 @@ macro_rules! points {
         )*
     )
 }
-fn name(args: &mut impl Iterator<Item=Primitive>) -> Result<Name> {
+fn name(args: &mut impl Iterator<Item = Primitive>) -> Result<Name> {
     args.next().ok_or(PdfError::NoOpArg)?.into_name()
 }
-fn number(args: &mut impl Iterator<Item=Primitive>) -> Result<f32> {
+fn number(args: &mut impl Iterator<Item = Primitive>) -> Result<f32> {
     args.next().ok_or(PdfError::NoOpArg)?.as_number()
 }
-fn string(args: &mut impl Iterator<Item=Primitive>) -> Result<PdfString> {
+fn string(args: &mut impl Iterator<Item = Primitive>) -> Result<PdfString> {
     args.next().ok_or(PdfError::NoOpArg)?.into_string()
 }
-fn point(args: &mut impl Iterator<Item=Primitive>) -> Result<Point> {
+fn point(args: &mut impl Iterator<Item = Primitive>) -> Result<Point> {
     let x = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let y = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     Ok(Point { x, y })
 }
-fn rect(args: &mut impl Iterator<Item=Primitive>) -> Result<Rect> {
+fn rect(args: &mut impl Iterator<Item = Primitive>) -> Result<ViewRect> {
     let x = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let y = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let width = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let height = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
-    Ok(Rect { x, y, width, height })
+    Ok(ViewRect {
+        x,
+        y,
+        width,
+        height,
+    })
 }
-fn rgb(args: &mut impl Iterator<Item=Primitive>) -> Result<Rgb> {
+fn rgb(args: &mut impl Iterator<Item = Primitive>) -> Result<Rgb> {
     let red = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let green = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let blue = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     Ok(Rgb { red, green, blue })
 }
-fn cmyk(args: &mut impl Iterator<Item=Primitive>) -> Result<Cmyk> {
+fn cmyk(args: &mut impl Iterator<Item = Primitive>) -> Result<Cmyk> {
     let cyan = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let magenta = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let yellow = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
     let key = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
-    Ok(Cmyk { cyan, magenta, yellow, key })
+    Ok(Cmyk {
+        cyan,
+        magenta,
+        yellow,
+        key,
+    })
 }
-fn matrix(args: &mut impl Iterator<Item=Primitive>) -> Result<Matrix> {
+fn matrix(args: &mut impl Iterator<Item = Primitive>) -> Result<Matrix> {
     Ok(Matrix {
         a: number(args)?,
         b: number(args)?,
@@ -101,11 +112,11 @@ fn matrix(args: &mut impl Iterator<Item=Primitive>) -> Result<Matrix> {
         f: number(args)?,
     })
 }
-fn array(args: &mut impl Iterator<Item=Primitive>) -> Result<Vec<Primitive>> {
+fn array(args: &mut impl Iterator<Item = Primitive>) -> Result<Vec<Primitive>> {
     match args.next() {
         Some(Primitive::Array(arr)) => Ok(arr),
         None => Ok(vec![]),
-        _ => Err(PdfError::NoOpArg)
+        _ => Err(PdfError::NoOpArg),
     }
 }
 
@@ -120,8 +131,10 @@ fn expand_abbr_name(name: SmallString, alt: &[(&str, &str)]) -> SmallString {
 fn expand_abbr(p: Primitive, alt: &[(&str, &str)]) -> Primitive {
     match p {
         Primitive::Name(name) => Primitive::Name(expand_abbr_name(name, alt)),
-        Primitive::Array(items) => Primitive::Array(items.into_iter().map(|p| expand_abbr(p, alt)).collect()),
-        p => p
+        Primitive::Array(items) => {
+            Primitive::Array(items.into_iter().map(|p| expand_abbr(p, alt)).collect())
+        }
+        p => p,
     }
 }
 
@@ -137,19 +150,22 @@ fn inline_image(lexer: &mut Lexer, resolve: &impl Resolve) -> Result<Arc<ImageXO
                 lexer.set_pos(backup_pos);
                 break;
             }
-            Ok(_) => bail!("invalid key type")
+            Ok(_) => bail!("invalid key type"),
         };
-        let key = expand_abbr_name(key, &[
-            ("BPC", "BitsPerComponent"),
-            ("CS", "ColorSpace"),
-            ("D", "Decode"),
-            ("DP", "DecodeParms"),
-            ("F", "Filter"),
-            ("H", "Height"),
-            ("IM", "ImageMask"),
-            ("I", "Interpolate"),
-            ("W", "Width"),
-        ]);
+        let key = expand_abbr_name(
+            key,
+            &[
+                ("BPC", "BitsPerComponent"),
+                ("CS", "ColorSpace"),
+                ("D", "Decode"),
+                ("DP", "DecodeParms"),
+                ("F", "Filter"),
+                ("H", "Height"),
+                ("IM", "ImageMask"),
+                ("I", "Interpolate"),
+                ("W", "Width"),
+            ],
+        );
         let val = parse_with_lexer(lexer, &NoResolve, ParseFlags::ANY)?;
         dict.insert(key, val);
     }
@@ -159,45 +175,87 @@ fn inline_image(lexer: &mut Lexer, resolve: &impl Resolve) -> Result<Arc<ImageXO
     // find the end before try parsing.
     if lexer.seek_substr("\nEI").is_none() {
         bail!("inline image exceeds expected data range");
-    }    
+    }
     let data_end = lexer.get_pos() - 3;
 
     // ugh
-    let bits_per_component = dict.get("BitsPerComponent").map(|p| p.as_integer()).transpose()?;
-    let color_space = dict.get("ColorSpace").map(|p| ColorSpace::from_primitive(expand_abbr(p.clone(), 
-        &[
-            ("G", "DeviceGray"),
-            ("RGB", "DeviceRGB"),
-            ("CMYK", "DeviceCMYK"),
-            ("I", "Indexed")
-        ]
-    ), resolve)).transpose()?;
-    let decode = dict.get("Decode").map(|p| Object::from_primitive(p.clone(), resolve)).transpose()?;
-    let decode_parms = dict.get("DecodeParms").map(|p| p.clone().resolve(resolve)?.into_dictionary()).transpose()?.unwrap_or_default();
-    let filter = dict.remove("Filter").map(|p| expand_abbr(p,
-        &[
-            ("AHx", "ASCIIHexDecode"),
-            ("A85", "ASCII85Decode"),
-            ("LZW", "LZWDecode"),
-            ("Fl", "FlateDecode"),
-            ("RL", "RunLengthDecode"),
-            ("CCF", "CCITTFaxDecode"),
-            ("DCT", "DCTDecode"),
-        ]
-    ));
+    let bits_per_component = dict
+        .get("BitsPerComponent")
+        .map(|p| p.as_integer())
+        .transpose()?;
+    let color_space = dict
+        .get("ColorSpace")
+        .map(|p| {
+            ColorSpace::from_primitive(
+                expand_abbr(
+                    p.clone(),
+                    &[
+                        ("G", "DeviceGray"),
+                        ("RGB", "DeviceRGB"),
+                        ("CMYK", "DeviceCMYK"),
+                        ("I", "Indexed"),
+                    ],
+                ),
+                resolve,
+            )
+        })
+        .transpose()?;
+    let decode = dict
+        .get("Decode")
+        .map(|p| Object::from_primitive(p.clone(), resolve))
+        .transpose()?;
+    let decode_parms = dict
+        .get("DecodeParms")
+        .map(|p| p.clone().resolve(resolve)?.into_dictionary())
+        .transpose()?
+        .unwrap_or_default();
+    let filter = dict.remove("Filter").map(|p| {
+        expand_abbr(
+            p,
+            &[
+                ("AHx", "ASCIIHexDecode"),
+                ("A85", "ASCII85Decode"),
+                ("LZW", "LZWDecode"),
+                ("Fl", "FlateDecode"),
+                ("RL", "RunLengthDecode"),
+                ("CCF", "CCITTFaxDecode"),
+                ("DCT", "DCTDecode"),
+            ],
+        )
+    });
     let filters = match filter {
-        Some(Primitive::Array(parts)) => parts.into_iter()
-            .map(|p| p.as_name().and_then(|kind| StreamFilter::from_kind_and_params(kind, decode_parms.clone(), resolve)))
+        Some(Primitive::Array(parts)) => parts
+            .into_iter()
+            .map(|p| {
+                p.as_name().and_then(|kind| {
+                    StreamFilter::from_kind_and_params(kind, decode_parms.clone(), resolve)
+                })
+            })
             .collect::<Result<_>>()?,
-        Some(Primitive::Name(kind)) => vec![StreamFilter::from_kind_and_params(&kind, decode_parms, resolve)?],
+        Some(Primitive::Name(kind)) => vec![StreamFilter::from_kind_and_params(
+            &kind,
+            decode_parms,
+            resolve,
+        )?],
         None => vec![],
-        _ => bail!("invalid filter")
+        _ => bail!("invalid filter"),
     };
-    
+
     let height = dict.require("InlineImage", "Height")?.as_u32()?;
-    let image_mask = dict.get("ImageMask").map(|p| p.as_bool()).transpose()?.unwrap_or(false);
-    let intent = dict.remove("Intent").map(|p| RenderingIntent::from_primitive(p, &NoResolve)).transpose()?;
-    let interpolate = dict.get("Interpolate").map(|p| p.as_bool()).transpose()?.unwrap_or(false);
+    let image_mask = dict
+        .get("ImageMask")
+        .map(|p| p.as_bool())
+        .transpose()?
+        .unwrap_or(false);
+    let intent = dict
+        .remove("Intent")
+        .map(|p| RenderingIntent::from_primitive(p, &NoResolve))
+        .transpose()?;
+    let interpolate = dict
+        .get("Interpolate")
+        .map(|p| p.as_bool())
+        .transpose()?
+        .unwrap_or(false);
     let width = dict.require("InlineImage", "Width")?.as_u32()?;
 
     let image_dict = ImageDict {
@@ -216,22 +274,24 @@ fn inline_image(lexer: &mut Lexer, resolve: &impl Resolve) -> Result<Arc<ImageXO
         other: dict,
     };
 
-    let data = lexer.new_substr(data_start .. data_end).to_vec();
+    let data = lexer.new_substr(data_start..data_end).to_vec();
 
-    Ok(Arc::new(ImageXObject { inner: Stream::from_compressed(image_dict, data, filters) }))
+    Ok(Arc::new(ImageXObject {
+        inner: Stream::from_compressed(image_dict, data, filters),
+    }))
 }
 
 struct OpBuilder {
     last: Point,
     compability_section: bool,
-    ops: Vec<Op>
+    ops: Vec<Op>,
 }
 impl OpBuilder {
     fn new() -> Self {
         OpBuilder {
             last: Point { x: 0., y: 0. },
             compability_section: false,
-            ops: Vec::new()
+            ops: Vec::new(),
         }
     }
     fn parse(&mut self, data: &[u8], resolve: &impl Resolve) -> Result<()> {
@@ -255,10 +315,10 @@ impl OpBuilder {
                     let op = t!(lexer.next());
                     let operator = t!(op.as_str(), op);
                     match self.add(operator, buffer.drain(..), &mut lexer, resolve) {
-                        Ok(()) => {},
+                        Ok(()) => {}
                         Err(e) if resolve.options().allow_invalid_ops => {
                             warn!("OP Err: {:?}", e);
-                        },
+                        }
                         Err(e) => return Err(e),
                     }
                 }
@@ -266,162 +326,208 @@ impl OpBuilder {
             match lexer.get_pos().cmp(&data.len()) {
                 Ordering::Greater => err!(PdfError::ContentReadPastBoundary),
                 Ordering::Less => (),
-                Ordering::Equal => break
+                Ordering::Equal => break,
             }
         }
         Ok(())
     }
-    fn add(&mut self, op: &str, mut args: impl Iterator<Item=Primitive>, lexer: &mut Lexer, resolve: &impl Resolve) -> Result<()> {
+    fn add(
+        &mut self,
+        op: &str,
+        mut args: impl Iterator<Item = Primitive>,
+        lexer: &mut Lexer,
+        resolve: &impl Resolve,
+    ) -> Result<()> {
         use Winding::*;
 
         let ops = &mut self.ops;
         let mut push = move |op| ops.push(op);
 
         match op {
-            "b"   => {
+            "b" => {
                 push(Op::Close);
                 push(Op::FillAndStroke { winding: NonZero });
-            },
-            "B"   => push(Op::FillAndStroke { winding: NonZero }),
-            "b*"  => {
+            }
+            "B" => push(Op::FillAndStroke { winding: NonZero }),
+            "b*" => {
                 push(Op::Close);
                 push(Op::FillAndStroke { winding: EvenOdd });
             }
-            "B*"  => push(Op::FillAndStroke { winding: EvenOdd }),
+            "B*" => push(Op::FillAndStroke { winding: EvenOdd }),
             "BDC" => push(Op::BeginMarkedContent {
                 tag: name(&mut args)?,
-                properties: Some(args.next().ok_or(PdfError::NoOpArg)?)
+                properties: Some(args.next().ok_or(PdfError::NoOpArg)?),
             }),
-            "BI"  => push(Op::InlineImage { image: inline_image(lexer, resolve)? }),
+            "BI" => push(Op::InlineImage {
+                image: inline_image(lexer, resolve)?,
+            }),
             "BMC" => push(Op::BeginMarkedContent {
                 tag: name(&mut args)?,
-                properties: None
+                properties: None,
             }),
-            "BT"  => push(Op::BeginText),
-            "BX"  => self.compability_section = true,
-            "c"   => {
+            "BT" => push(Op::BeginText),
+            "BX" => self.compability_section = true,
+            "c" => {
                 points!(args, c1, c2, p);
                 push(Op::CurveTo { c1, c2, p });
                 self.last = p;
             }
-            "cm"  => {
+            "cm" => {
                 numbers!(args, a, b, c, d, e, f);
-                push(Op::Transform { matrix: Matrix { a, b, c, d, e, f }});
+                push(Op::Transform {
+                    matrix: Matrix { a, b, c, d, e, f },
+                });
             }
-            "CS"  => {
+            "CS" => {
                 names!(args, name);
                 push(Op::StrokeColorSpace { name });
             }
-            "cs"  => {
+            "cs" => {
                 names!(args, name);
                 push(Op::FillColorSpace { name });
             }
-            "d"  => {
+            "d" => {
                 let p = args.next().ok_or(PdfError::NoOpArg)?;
-                let pattern = p.as_array()?.iter().map(|p| p.as_number()).collect::<Result<Vec<f32>, PdfError>>()?;
+                let pattern = p
+                    .as_array()?
+                    .iter()
+                    .map(|p| p.as_number())
+                    .collect::<Result<Vec<f32>, PdfError>>()?;
                 let phase = args.next().ok_or(PdfError::NoOpArg)?.as_number()?;
                 push(Op::Dash { pattern, phase });
             }
-            "d0"  => {}
-            "d1"  => {}
+            "d0" => {}
+            "d1" => {}
             "Do" | "Do0" => {
                 names!(args, name);
                 push(Op::XObject { name });
             }
-            "DP"  => push(Op::MarkedContentPoint {
+            "DP" => push(Op::MarkedContentPoint {
                 tag: name(&mut args)?,
-                properties: Some(args.next().ok_or(PdfError::NoOpArg)?)
+                properties: Some(args.next().ok_or(PdfError::NoOpArg)?),
             }),
-            "EI"  => bail!("Parse Error. Unexpected 'EI'"),
+            "EI" => bail!("Parse Error. Unexpected 'EI'"),
             "EMC" => push(Op::EndMarkedContent),
-            "ET"  => push(Op::EndText),
-            "EX"  => self.compability_section = false,
-            "f" |
-            "F"   => push(Op::Fill { winding: NonZero }),
-            "f*"  => push(Op::Fill { winding: EvenOdd }),
-            "G"   => push(Op::StrokeColor { color: Color::Gray(number(&mut args)?) }),
-            "g"   => push(Op::FillColor { color: Color::Gray(number(&mut args)?) }),
-            "gs"  => push(Op::GraphicsState { name: name(&mut args)? }),
-            "h"   => push(Op::Close),
-            "i"   => push(Op::Flatness { tolerance: number(&mut args)? }),
-            "ID"  => bail!("Parse Error. Unexpected 'ID'"),
-            "j"   => {
+            "ET" => push(Op::EndText),
+            "EX" => self.compability_section = false,
+            "f" | "F" => push(Op::Fill { winding: NonZero }),
+            "f*" => push(Op::Fill { winding: EvenOdd }),
+            "G" => push(Op::StrokeColor {
+                color: Color::Gray(number(&mut args)?),
+            }),
+            "g" => push(Op::FillColor {
+                color: Color::Gray(number(&mut args)?),
+            }),
+            "gs" => push(Op::GraphicsState {
+                name: name(&mut args)?,
+            }),
+            "h" => push(Op::Close),
+            "i" => push(Op::Flatness {
+                tolerance: number(&mut args)?,
+            }),
+            "ID" => bail!("Parse Error. Unexpected 'ID'"),
+            "j" => {
                 let n = args.next().ok_or(PdfError::NoOpArg)?.as_integer()?;
                 let join = match n {
                     0 => LineJoin::Miter,
                     1 => LineJoin::Round,
                     2 => LineJoin::Bevel,
-                    _ => bail!("invalid line join {}", n)
+                    _ => bail!("invalid line join {}", n),
                 };
                 push(Op::LineJoin { join });
             }
-            "J"   => {
+            "J" => {
                 let n = args.next().ok_or(PdfError::NoOpArg)?.as_integer()?;
                 let cap = match n {
                     0 => LineCap::Butt,
                     1 => LineCap::Round,
                     2 => LineCap::Square,
-                    _ => bail!("invalid line cap {}", n)
+                    _ => bail!("invalid line cap {}", n),
                 };
                 push(Op::LineCap { cap });
             }
-            "K"   => {
+            "K" => {
                 let color = Color::Cmyk(cmyk(&mut args)?);
                 push(Op::StrokeColor { color });
             }
-            "k"   => {
+            "k" => {
                 let color = Color::Cmyk(cmyk(&mut args)?);
                 push(Op::FillColor { color });
             }
-            "l"   => {
+            "l" => {
                 let p = point(&mut args)?;
                 push(Op::LineTo { p });
                 self.last = p;
             }
-            "m"   => {
+            "m" => {
                 let p = point(&mut args)?;
                 push(Op::MoveTo { p });
                 self.last = p;
             }
-            "M"   => push(Op::MiterLimit { limit: number(&mut args)? }),
-            "MP"  => push(Op::MarkedContentPoint { tag: name(&mut args)?, properties: None }),
-            "n"   => push(Op::EndPath),
-            "q"   => push(Op::Save),
-            "Q"   => push(Op::Restore),
-            "re"  => push(Op::Rect { rect: rect(&mut args)? }),
-            "RG"  => push(Op::StrokeColor { color: Color::Rgb(rgb(&mut args)?) }),
-            "rg"  => push(Op::FillColor { color: Color::Rgb(rgb(&mut args)?) }),
-            "ri"  => {
+            "M" => push(Op::MiterLimit {
+                limit: number(&mut args)?,
+            }),
+            "MP" => push(Op::MarkedContentPoint {
+                tag: name(&mut args)?,
+                properties: None,
+            }),
+            "n" => push(Op::EndPath),
+            "q" => push(Op::Save),
+            "Q" => push(Op::Restore),
+            "re" => push(Op::Rect {
+                rect: rect(&mut args)?,
+            }),
+            "RG" => push(Op::StrokeColor {
+                color: Color::Rgb(rgb(&mut args)?),
+            }),
+            "rg" => push(Op::FillColor {
+                color: Color::Rgb(rgb(&mut args)?),
+            }),
+            "ri" => {
                 let s = name(&mut args)?;
-                let intent = RenderingIntent::from_str(&s)
-                    .ok_or_else(|| PdfError::Other { msg: format!("invalid rendering intent {}", s) })?;
+                let intent = RenderingIntent::from_str(&s).ok_or_else(|| PdfError::Other {
+                    msg: format!("invalid rendering intent {}", s),
+                })?;
                 push(Op::RenderingIntent { intent });
-            },
-            "s"   => {
+            }
+            "s" => {
                 push(Op::Close);
                 push(Op::Stroke);
             }
-            "S"   => push(Op::Stroke),
+            "S" => push(Op::Stroke),
             "SC" | "SCN" => {
-                push(Op::StrokeColor { color: Color::Other(args.collect()) });
+                push(Op::StrokeColor {
+                    color: Color::Other(args.collect()),
+                });
             }
             "sc" | "scn" => {
-                push(Op::FillColor { color: Color::Other(args.collect()) });
+                push(Op::FillColor {
+                    color: Color::Other(args.collect()),
+                });
             }
-            "sh"  => {
-
-            }
-            "T*"  => push(Op::TextNewline),
-            "Tc"  => push(Op::CharSpacing { char_space: number(&mut args)? }),
-            "Td"  => push(Op::MoveTextPosition { translation: point(&mut args)? }),
-            "TD"  => {
+            "sh" => {}
+            "T*" => push(Op::TextNewline),
+            "Tc" => push(Op::CharSpacing {
+                char_space: number(&mut args)?,
+            }),
+            "Td" => push(Op::MoveTextPosition {
+                translation: point(&mut args)?,
+            }),
+            "TD" => {
                 let translation = point(&mut args)?;
-                push(Op::Leading { leading: -translation.y });
+                push(Op::Leading {
+                    leading: -translation.y,
+                });
                 push(Op::MoveTextPosition { translation });
             }
-            "Tf"  => push(Op::TextFont { name: name(&mut args)?, size: number(&mut args)? }),
-            "Tj"  => push(Op::TextDraw { text: string(&mut args)? }),
-            "TJ"  => {
+            "Tf" => push(Op::TextFont {
+                name: name(&mut args)?,
+                size: number(&mut args)?,
+            }),
+            "Tj" => push(Op::TextDraw {
+                text: string(&mut args)?,
+            }),
+            "TJ" => {
                 let mut result = Vec::<TextDrawAdjusted>::new();
 
                 for spacing_or_text in array(&mut args)?.into_iter() {
@@ -429,7 +535,7 @@ impl OpBuilder {
                         Primitive::Integer(i) => TextDrawAdjusted::Spacing(i as f32),
                         Primitive::Number(f) => TextDrawAdjusted::Spacing(f),
                         Primitive::String(text) => TextDrawAdjusted::Text(text),
-                        p => bail!("invalid primitive in TJ operator: {:?}", p)
+                        p => bail!("invalid primitive in TJ operator: {:?}", p),
                     };
 
                     result.push(spacing_or_text);
@@ -437,9 +543,13 @@ impl OpBuilder {
 
                 push(Op::TextDrawAdjusted { array: result })
             }
-            "TL"  => push(Op::Leading { leading: number(&mut args)? }),
-            "Tm"  => push(Op::SetTextMatrix { matrix: matrix(&mut args)? }), 
-            "Tr"  => {
+            "TL" => push(Op::Leading {
+                leading: number(&mut args)?,
+            }),
+            "Tm" => push(Op::SetTextMatrix {
+                matrix: matrix(&mut args)?,
+            }),
+            "Tr" => {
                 use TextMode::*;
 
                 let n = args.next().ok_or(PdfError::NoOpArg)?.as_integer()?;
@@ -456,35 +566,55 @@ impl OpBuilder {
                 };
                 push(Op::TextRenderMode { mode });
             }
-            "Ts"  => push(Op::TextRise { rise: number(&mut args)? }),
-            "Tw"  => push(Op::WordSpacing { word_space: number(&mut args)? }),
-            "Tz"  => push(Op::TextScaling { horiz_scale: number(&mut args)? }),
-            "v"   => {
+            "Ts" => push(Op::TextRise {
+                rise: number(&mut args)?,
+            }),
+            "Tw" => push(Op::WordSpacing {
+                word_space: number(&mut args)?,
+            }),
+            "Tz" => push(Op::TextScaling {
+                horiz_scale: number(&mut args)?,
+            }),
+            "v" => {
                 points!(args, c2, p);
-                push(Op::CurveTo { c1: self.last, c2, p });
+                push(Op::CurveTo {
+                    c1: self.last,
+                    c2,
+                    p,
+                });
                 self.last = p;
             }
-            "w"   => push(Op::LineWidth { width: number(&mut args)? }),
-            "W"   => push(Op::Clip { winding: NonZero }),
-            "W*"  => push(Op::Clip { winding: EvenOdd }),
-            "y"   => {
+            "w" => push(Op::LineWidth {
+                width: number(&mut args)?,
+            }),
+            "W" => push(Op::Clip { winding: NonZero }),
+            "W*" => push(Op::Clip { winding: EvenOdd }),
+            "y" => {
                 points!(args, c1, p);
                 push(Op::CurveTo { c1, c2: p, p });
                 self.last = p;
             }
-            "'"   => {
+            "'" => {
                 push(Op::TextNewline);
-                push(Op::TextDraw { text: string(&mut args)? });
+                push(Op::TextDraw {
+                    text: string(&mut args)?,
+                });
             }
-            "\""  => {
-                push(Op::WordSpacing { word_space: number(&mut args)? });
-                push(Op::CharSpacing { char_space: number(&mut args)? });
+            "\"" => {
+                push(Op::WordSpacing {
+                    word_space: number(&mut args)?,
+                });
+                push(Op::CharSpacing {
+                    char_space: number(&mut args)?,
+                });
                 push(Op::TextNewline);
-                push(Op::TextDraw { text: string(&mut args)? });
+                push(Op::TextDraw {
+                    text: string(&mut args)?,
+                });
             }
             o if !self.compability_section => {
                 bail!("invalid operator {}", o)
-            },
+            }
             _ => {}
         }
         Ok(())
@@ -504,7 +634,9 @@ impl Object for Content {
                     parts.push(part);
                 }
             }
-            Primitive::Reference(r) => return Self::from_primitive(t!(resolve.resolve(r)), resolve),
+            Primitive::Reference(r) => {
+                return Self::from_primitive(t!(resolve.resolve(r)), resolve)
+            }
             p => {
                 let part = t!(ContentStream::from_primitive(p, resolve));
                 parts.push(part);
@@ -534,9 +666,7 @@ impl Object for FormXObject {
     /// Convert primitive to Self
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         let stream = t!(Stream::<FormDict>::from_primitive(p, resolve));
-        Ok(FormXObject {
-            stream,
-        })
+        Ok(FormXObject { stream })
     }
 }
 impl ObjectWrite for FormXObject {
@@ -547,7 +677,7 @@ impl ObjectWrite for FormXObject {
     }
 }
 
-#[allow(clippy::float_cmp)]  // TODO
+#[allow(clippy::float_cmp)] // TODO
 pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
     use std::io::Write;
 
@@ -558,23 +688,35 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
     while ops.len() > 0 {
         let mut advance = 1;
         match ops[0] {
-            Op::BeginMarkedContent { ref tag, properties: Some(ref name) } => {
+            Op::BeginMarkedContent {
+                ref tag,
+                properties: Some(ref name),
+            } => {
                 serialize_name(tag, f)?;
                 write!(f, " ")?;
                 name.serialize(f)?;
                 writeln!(f, " BDC")?;
             }
-            Op::BeginMarkedContent { ref tag, properties: None } => {
+            Op::BeginMarkedContent {
+                ref tag,
+                properties: None,
+            } => {
                 serialize_name(tag, f)?;
                 writeln!(f, " BMC")?;
             }
-            Op::MarkedContentPoint { ref tag, properties: Some(ref name) } => {
+            Op::MarkedContentPoint {
+                ref tag,
+                properties: Some(ref name),
+            } => {
                 serialize_name(tag, f)?;
                 write!(f, " ")?;
                 name.serialize(f)?;
                 writeln!(f, " DP")?;
             }
-            Op::MarkedContentPoint { ref tag, properties: None } => {
+            Op::MarkedContentPoint {
+                ref tag,
+                properties: None,
+            } => {
                 serialize_name(tag, f)?;
                 writeln!(f, " MP")?;
             }
@@ -584,16 +726,20 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                     writeln!(f, "s")?;
                     advance += 1;
                 }
-                Some(Op::FillAndStroke { winding: Winding::NonZero }) => {
+                Some(Op::FillAndStroke {
+                    winding: Winding::NonZero,
+                }) => {
                     writeln!(f, "b")?;
                     advance += 1;
                 }
-                Some(Op::FillAndStroke { winding: Winding::EvenOdd }) => {
+                Some(Op::FillAndStroke {
+                    winding: Winding::EvenOdd,
+                }) => {
                     writeln!(f, "b*")?;
                     advance += 1;
                 }
                 _ => writeln!(f, "h")?,
-            }
+            },
             Op::MoveTo { p } => {
                 writeln!(f, "{} m", p)?;
                 current_point = Some(p);
@@ -601,7 +747,7 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
             Op::LineTo { p } => {
                 writeln!(f, "{} l", p)?;
                 current_point = Some(p);
-            },
+            }
             Op::CurveTo { c1, c2, p } => {
                 if Some(c1) == current_point {
                     writeln!(f, "{} {} v", c2, p)?;
@@ -611,25 +757,39 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                     writeln!(f, "{} {} {} c", c1, c2, p)?;
                 }
                 current_point = Some(p);
-            },
+            }
             Op::Rect { rect } => writeln!(f, "{} re", rect)?,
             Op::EndPath => writeln!(f, "n")?,
             Op::Stroke => writeln!(f, "S")?,
-            Op::FillAndStroke { winding: Winding::NonZero } => writeln!(f, "B")?,
-            Op::FillAndStroke { winding: Winding::EvenOdd } => writeln!(f, "B*")?,
-            Op::Fill { winding: Winding::NonZero } => writeln!(f, "f")?,
-            Op::Fill { winding: Winding::EvenOdd } => writeln!(f, "f*")?,
+            Op::FillAndStroke {
+                winding: Winding::NonZero,
+            } => writeln!(f, "B")?,
+            Op::FillAndStroke {
+                winding: Winding::EvenOdd,
+            } => writeln!(f, "B*")?,
+            Op::Fill {
+                winding: Winding::NonZero,
+            } => writeln!(f, "f")?,
+            Op::Fill {
+                winding: Winding::EvenOdd,
+            } => writeln!(f, "f*")?,
             Op::Shade { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " sh")?;
-            },
-            Op::Clip { winding: Winding::NonZero } => writeln!(f, "W")?,
-            Op::Clip { winding: Winding::EvenOdd } => writeln!(f, "W*")?,
+            }
+            Op::Clip {
+                winding: Winding::NonZero,
+            } => writeln!(f, "W")?,
+            Op::Clip {
+                winding: Winding::EvenOdd,
+            } => writeln!(f, "W*")?,
             Op::Save => writeln!(f, "q")?,
             Op::Restore => writeln!(f, "Q")?,
             Op::Transform { matrix } => writeln!(f, "{} cm", matrix)?,
             Op::LineWidth { width } => writeln!(f, "{} w", width)?,
-            Op::Dash { ref pattern, phase } => write!(f, "[{}] {} d", pattern.iter().format(" "), phase)?,
+            Op::Dash { ref pattern, phase } => {
+                write!(f, "[{}] {} d", pattern.iter().format(" "), phase)?
+            }
             Op::LineJoin { join } => writeln!(f, "{} j", join as u8)?,
             Op::LineCap { cap } => writeln!(f, "{} J", cap as u8)?,
             Op::MiterLimit { limit } => writeln!(f, "{} M", limit)?,
@@ -637,21 +797,37 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
             Op::GraphicsState { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " gs")?;
-            },
-            Op::StrokeColor { color: Color::Gray(g) } => writeln!(f, "{} G", g)?,
-            Op::StrokeColor { color: Color::Rgb(rgb) } => writeln!(f, "{} RG", rgb)?,
-            Op::StrokeColor { color: Color::Cmyk(cmyk) } => writeln!(f, "{} K", cmyk)?,
-            Op::StrokeColor { color: Color::Other(ref args) } =>  {
+            }
+            Op::StrokeColor {
+                color: Color::Gray(g),
+            } => writeln!(f, "{} G", g)?,
+            Op::StrokeColor {
+                color: Color::Rgb(rgb),
+            } => writeln!(f, "{} RG", rgb)?,
+            Op::StrokeColor {
+                color: Color::Cmyk(cmyk),
+            } => writeln!(f, "{} K", cmyk)?,
+            Op::StrokeColor {
+                color: Color::Other(ref args),
+            } => {
                 for p in args {
                     p.serialize(f)?;
                     write!(f, " ")?;
                 }
                 writeln!(f, "SCN")?;
             }
-            Op::FillColor { color: Color::Gray(g) } => writeln!(f, "{} g", g)?,
-            Op::FillColor { color: Color::Rgb(rgb) } => writeln!(f, "{} rg", rgb)?,
-            Op::FillColor { color: Color::Cmyk(cmyk) } => writeln!(f, "{} k", cmyk)?,
-            Op::FillColor { color: Color::Other(ref args) } => {
+            Op::FillColor {
+                color: Color::Gray(g),
+            } => writeln!(f, "{} g", g)?,
+            Op::FillColor {
+                color: Color::Rgb(rgb),
+            } => writeln!(f, "{} rg", rgb)?,
+            Op::FillColor {
+                color: Color::Cmyk(cmyk),
+            } => writeln!(f, "{} k", cmyk)?,
+            Op::FillColor {
+                color: Color::Other(ref args),
+            } => {
                 for p in args {
                     p.serialize(f)?;
                     write!(f, " ")?;
@@ -661,23 +837,20 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
             Op::FillColorSpace { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " cs")?;
-            },
+            }
             Op::StrokeColorSpace { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " CS")?;
-            },
+            }
 
             Op::RenderingIntent { intent } => writeln!(f, "{} ri", intent.to_str())?,
             Op::BeginText => writeln!(f, "BT")?,
             Op::EndText => writeln!(f, "ET")?,
             Op::CharSpacing { char_space } => writeln!(f, "{} Tc", char_space)?,
             Op::WordSpacing { word_space } => {
-                if let [
-                    Op::CharSpacing { char_space },
-                    Op::TextNewline,
-                    Op::TextDraw { ref text },
-                    ..
-                ] = ops[1..] {
+                if let [Op::CharSpacing { char_space }, Op::TextNewline, Op::TextDraw { ref text }, ..] =
+                    ops[1..]
+                {
                     write!(f, "{} {} ", word_space, char_space)?;
                     text.serialize(f)?;
                     writeln!(f, " \"")?;
@@ -695,14 +868,16 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                 _ => {
                     writeln!(f, "{} TL", leading)?;
                 }
-            }
+            },
             Op::TextFont { ref name, ref size } => {
                 serialize_name(name, f)?;
                 writeln!(f, " {} Tf", size)?;
-            },
+            }
             Op::TextRenderMode { mode } => writeln!(f, "{} Tr", mode as u8)?,
             Op::TextRise { rise } => writeln!(f, "{} Ts", rise)?,
-            Op::MoveTextPosition { translation } => writeln!(f, "{} {} Td", translation.x, translation.y)?,
+            Op::MoveTextPosition { translation } => {
+                writeln!(f, "{} {} Td", translation.x, translation.y)?
+            }
             Op::SetTextMatrix { matrix } => writeln!(f, "{} Tm", matrix)?,
             Op::TextNewline => {
                 if let [Op::TextDraw { ref text }, ..] = ops[1..] {
@@ -712,11 +887,11 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                 } else {
                     writeln!(f, "T*")?;
                 }
-            },
+            }
             Op::TextDraw { ref text } => {
                 text.serialize(f)?;
                 writeln!(f, " Tj")?;
-            },
+            }
             Op::TextDrawAdjusted { ref array } => {
                 write!(f, "[")?;
                 for (i, val) in array.iter().enumerate() {
@@ -729,12 +904,12 @@ pub fn serialize_ops(mut ops: &[Op]) -> Result<Vec<u8>> {
                     }
                 }
                 writeln!(f, "] TJ")?;
-            },
+            }
             Op::InlineImage { image: _ } => unimplemented!(),
             Op::XObject { ref name } => {
                 serialize_name(name, f)?;
                 writeln!(f, " Do")?;
-            },
+            }
         }
         ops = &ops[advance..];
     }
@@ -745,7 +920,7 @@ impl Content {
     pub fn from_ops(operations: Vec<Op>) -> Self {
         let data = serialize_ops(&operations).unwrap();
         Content {
-            parts: vec![Stream::new((), data)]
+            parts: vec![Stream::new((), data)],
         }
     }
 }
@@ -764,7 +939,7 @@ impl ObjectWrite for Content {
 #[derive(Debug, Copy, Clone, PartialEq, DataSize)]
 pub enum Winding {
     EvenOdd,
-    NonZero
+    NonZero,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, DataSize)]
@@ -788,7 +963,7 @@ pub struct PdfSpace();
 #[repr(C, align(8))]
 pub struct Point {
     pub x: f32,
-    pub y: f32
+    pub y: f32,
 }
 impl Display for Point {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -828,40 +1003,88 @@ impl From<euclid::Vector2D<f32, PdfSpace>> for Point {
     }
 }
 
+/// ISO 32000-2:2020(E) Table 58 Pg 186 - ViewRect
+/// Path construction operators - {x y width height re}
+/// Append a rectangle to the current path as a complete
+/// subpath, with lower-left corner (x, y) and dimensions
+/// width and height in user space.
 #[derive(Debug, Copy, Clone, PartialEq, DataSize)]
 #[repr(C, align(8))]
-pub struct Rect {
+pub struct ViewRect {
     pub x: f32,
     pub y: f32,
     pub width: f32,
     pub height: f32,
 }
-impl Display for Rect {
+impl Display for ViewRect {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {} {} {}", self.x, self.y, self.width, self.height)
     }
 }
+impl From<crate::object::Rectangle> for ViewRect {
+    fn from(value: crate::object::Rectangle) -> Self {
+        let x = value.left;
+        let y = value.bottom;
+        let width = value.right - value.left;
+        let height = value.top - value.bottom;
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+impl From<ViewRect> for crate::object::Rectangle {
+    fn from(value: ViewRect) -> Self {
+        let left = value.x;
+        let bottom = value.y;
+        let right = left + value.width;
+        let top = bottom + value.height;
+        Self {
+            top,
+            left,
+            bottom,
+            right,
+        }
+    }
+}
 #[cfg(feature = "euclid")]
-impl Into<euclid::Box2D<f32, PdfSpace>> for Rect {
+impl Into<euclid::Box2D<f32, PdfSpace>> for ViewRect {
     fn into(self) -> euclid::Box2D<f32, PdfSpace> {
-        let Rect { x, y, width, height } = self;
+        let ViewRect {
+            x,
+            y,
+            width,
+            height,
+        } = self;
 
         assert!(width > 0.0);
         assert!(height > 0.0);
 
-        euclid::Box2D::new(euclid::Point2D::new(x, y), euclid::Point2D::new(x + width, y + height))
+        euclid::Box2D::new(
+            euclid::Point2D::new(x, y),
+            euclid::Point2D::new(x + width, y + height),
+        )
     }
 }
 #[cfg(feature = "euclid")]
-impl From<euclid::Box2D<f32, PdfSpace>> for Rect {
+impl From<euclid::Box2D<f32, PdfSpace>> for ViewRect {
     fn from(from: euclid::Box2D<f32, PdfSpace>) -> Self {
-        let euclid::Box2D { min: euclid::Point2D { x, y, .. }, max: euclid::Point2D { x: x2, y: y2, .. }, .. } = from;
+        let euclid::Box2D {
+            min: euclid::Point2D { x, y, .. },
+            max: euclid::Point2D { x: x2, y: y2, .. },
+            ..
+        } = from;
 
         assert!(x < x2);
         assert!(y < y2);
 
-        Rect {
-            x, y, width: x2 - x, height: y2 - y
+        ViewRect {
+            x,
+            y,
+            width: x2 - x,
+            height: y2 - y,
         }
     }
 }
@@ -878,7 +1101,11 @@ pub struct Matrix {
 }
 impl Display for Matrix {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} {} {} {} {}", self.a, self.b, self.c, self.d, self.e, self.f)
+        write!(
+            f,
+            "{} {} {} {} {} {}",
+            self.a, self.b, self.c, self.d, self.e, self.f
+        )
     }
 }
 impl Default for Matrix {
@@ -907,7 +1134,7 @@ impl ObjectWrite for Matrix {
 #[cfg(feature = "euclid")]
 impl Into<euclid::Transform2D<f32, PdfSpace, PdfSpace>> for Matrix {
     fn into(self) -> euclid::Transform2D<f32, PdfSpace, PdfSpace> {
-        let Matrix { a, b, c, d, e, f} = self;
+        let Matrix { a, b, c, d, e, f } = self;
 
         euclid::Transform2D::new(a, b, c, d, e, f)
     }
@@ -915,11 +1142,17 @@ impl Into<euclid::Transform2D<f32, PdfSpace, PdfSpace>> for Matrix {
 #[cfg(feature = "euclid")]
 impl From<euclid::Transform2D<f32, PdfSpace, PdfSpace>> for Matrix {
     fn from(from: euclid::Transform2D<f32, PdfSpace, PdfSpace>) -> Self {
-        let euclid::Transform2D { m11: a, m12: b, m21: c, m22: d, m31: e, m32: f, .. } = from;
+        let euclid::Transform2D {
+            m11: a,
+            m12: b,
+            m21: c,
+            m22: d,
+            m31: e,
+            m32: f,
+            ..
+        } = from;
 
-        Matrix {
-            a, b, c, d, e, f
-        }
+        Matrix { a, b, c, d, e, f }
     }
 }
 
@@ -938,7 +1171,7 @@ pub enum TextMode {
     FillThenStroke,
     Invisible,
     FillAndClip,
-    StrokeAndClip
+    StrokeAndClip,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, DataSize)]
@@ -962,7 +1195,11 @@ pub struct Cmyk {
 }
 impl Display for Cmyk {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} {} {}", self.cyan, self.magenta, self.yellow, self.key)
+        write!(
+            f,
+            "{} {} {} {}",
+            self.cyan, self.magenta, self.yellow, self.key
+        )
     }
 }
 
@@ -982,145 +1219,240 @@ impl Display for TextDrawAdjusted {
 }
 
 /// Graphics Operator
-/// 
+///
 /// See PDF32000 A.2
 #[derive(Debug, Clone, DataSize)]
 pub enum Op {
     /// Begin a marked comtent sequence
-    /// 
+    ///
     /// Pairs with the following EndMarkedContent.
-    /// 
+    ///
     /// generated by operators `BMC` and `BDC`
-    BeginMarkedContent { tag: Name, properties: Option<Primitive> },
+    BeginMarkedContent {
+        tag: Name,
+        properties: Option<Primitive>,
+    },
 
     /// End a marked content sequence.
-    /// 
+    ///
     /// Pairs with the previous BeginMarkedContent.
-    /// 
+    ///
     /// generated by operator `EMC`
     EndMarkedContent,
 
     /// A marked content point.
-    /// 
+    ///
     /// generated by operators `MP` and `DP`.
-    MarkedContentPoint { tag: Name, properties: Option<Primitive> },
-
+    MarkedContentPoint {
+        tag: Name,
+        properties: Option<Primitive>,
+    },
 
     Close,
-    MoveTo { p: Point },
-    LineTo { p: Point },
-    CurveTo { c1: Point, c2: Point, p: Point },
-    Rect { rect: Rect },
+    MoveTo {
+        p: Point,
+    },
+    LineTo {
+        p: Point,
+    },
+    CurveTo {
+        c1: Point,
+        c2: Point,
+        p: Point,
+    },
+    Rect {
+        rect: ViewRect,
+    },
     EndPath,
 
     Stroke,
 
     /// Fill and Stroke operation
-    /// 
+    ///
     /// generated by operators `b`, `B`, `b*`, `B*`
     /// `close` indicates whether the path should be closed first
-    FillAndStroke { winding: Winding },
+    FillAndStroke {
+        winding: Winding,
+    },
 
-
-    Fill { winding: Winding },
+    Fill {
+        winding: Winding,
+    },
 
     /// Fill using the named shading pattern
-    /// 
+    ///
     /// operator: `sh`
-    Shade { name: Name },
+    Shade {
+        name: Name,
+    },
 
-    Clip { winding: Winding },
+    Clip {
+        winding: Winding,
+    },
 
     Save,
     Restore,
 
-    Transform { matrix: Matrix },
+    Transform {
+        matrix: Matrix,
+    },
 
-    LineWidth { width: f32 },
-    Dash { pattern: Vec<f32>, phase: f32 },
-    LineJoin { join: LineJoin },
-    LineCap { cap: LineCap },
-    MiterLimit { limit: f32 },
-    Flatness { tolerance: f32 },
+    LineWidth {
+        width: f32,
+    },
+    Dash {
+        pattern: Vec<f32>,
+        phase: f32,
+    },
+    LineJoin {
+        join: LineJoin,
+    },
+    LineCap {
+        cap: LineCap,
+    },
+    MiterLimit {
+        limit: f32,
+    },
+    Flatness {
+        tolerance: f32,
+    },
 
-    GraphicsState { name: Name },
+    GraphicsState {
+        name: Name,
+    },
 
-    StrokeColor { color: Color },
-    FillColor { color: Color },
+    StrokeColor {
+        color: Color,
+    },
+    FillColor {
+        color: Color,
+    },
 
-    FillColorSpace { name: Name },
-    StrokeColorSpace { name: Name },
+    FillColorSpace {
+        name: Name,
+    },
+    StrokeColorSpace {
+        name: Name,
+    },
 
-    RenderingIntent { intent: RenderingIntent },
+    RenderingIntent {
+        intent: RenderingIntent,
+    },
 
     BeginText,
     EndText,
 
-    CharSpacing { char_space: f32 },
-    WordSpacing { word_space: f32 },
-    TextScaling { horiz_scale: f32 },
-    Leading { leading: f32 },
-    TextFont { name: Name, size: f32 },
-    TextRenderMode { mode: TextMode },
+    CharSpacing {
+        char_space: f32,
+    },
+    WordSpacing {
+        word_space: f32,
+    },
+    TextScaling {
+        horiz_scale: f32,
+    },
+    Leading {
+        leading: f32,
+    },
+    TextFont {
+        name: Name,
+        size: f32,
+    },
+    TextRenderMode {
+        mode: TextMode,
+    },
 
     /// `Ts`
-    TextRise { rise: f32 },
+    TextRise {
+        rise: f32,
+    },
 
     /// `Td`, `TD`
-    MoveTextPosition { translation: Point },
+    MoveTextPosition {
+        translation: Point,
+    },
 
     /// `Tm`
-    SetTextMatrix { matrix: Matrix },
+    SetTextMatrix {
+        matrix: Matrix,
+    },
 
     /// `T*`
     TextNewline,
 
     /// `Tj`
-    TextDraw { text: PdfString },
+    TextDraw {
+        text: PdfString,
+    },
 
-    TextDrawAdjusted { array: Vec<TextDrawAdjusted> },
+    TextDrawAdjusted {
+        array: Vec<TextDrawAdjusted>,
+    },
 
-    XObject { name: Name },
+    XObject {
+        name: Name,
+    },
 
-    InlineImage { image: Arc<ImageXObject> },
+    InlineImage {
+        image: Arc<ImageXObject>,
+    },
 }
 
-pub fn deep_clone_op(op: &Op, cloner: &mut impl Cloner, old_resources: &Resources, resources: &mut Resources) -> Result<Op> {
+pub fn deep_clone_op(
+    op: &Op,
+    cloner: &mut impl Cloner,
+    old_resources: &Resources,
+    resources: &mut Resources,
+) -> Result<Op> {
     match *op {
         Op::GraphicsState { ref name } => {
             if !resources.graphics_states.contains_key(name) {
                 if let Some(gs) = old_resources.graphics_states.get(name) {
-                    resources.graphics_states.insert(name.clone(), gs.deep_clone(cloner)?);
+                    resources
+                        .graphics_states
+                        .insert(name.clone(), gs.deep_clone(cloner)?);
                 }
             }
             Ok(Op::GraphicsState { name: name.clone() })
         }
-        Op::MarkedContentPoint { ref tag, ref properties } => {
-            Ok(Op::MarkedContentPoint { tag: tag.clone(), properties: properties.deep_clone(cloner)? })
-        }
-        Op::BeginMarkedContent { ref tag, ref properties } => {
-            Ok(Op::BeginMarkedContent { tag: tag.clone(), properties: properties.deep_clone(cloner)? })
-        }
+        Op::MarkedContentPoint {
+            ref tag,
+            ref properties,
+        } => Ok(Op::MarkedContentPoint {
+            tag: tag.clone(),
+            properties: properties.deep_clone(cloner)?,
+        }),
+        Op::BeginMarkedContent {
+            ref tag,
+            ref properties,
+        } => Ok(Op::BeginMarkedContent {
+            tag: tag.clone(),
+            properties: properties.deep_clone(cloner)?,
+        }),
         Op::TextFont { ref name, size } => {
             if !resources.fonts.contains_key(name) {
                 if let Some(f) = old_resources.fonts.get(name) {
                     resources.fonts.insert(name.clone(), f.deep_clone(cloner)?);
                 }
             }
-            Ok(Op::TextFont { name: name.clone(), size })
+            Ok(Op::TextFont {
+                name: name.clone(),
+                size,
+            })
         }
         Op::XObject { ref name } => {
             if !resources.xobjects.contains_key(name) {
                 if let Some(xo) = old_resources.xobjects.get(name) {
-                    resources.xobjects.insert(name.clone(), xo.deep_clone(cloner)?);
+                    resources
+                        .xobjects
+                        .insert(name.clone(), xo.deep_clone(cloner)?);
                 }
             }
             Ok(Op::XObject { name: name.clone() })
         }
-        ref op => Ok(op.clone())
+        ref op => Ok(op.clone()),
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -1140,6 +1472,6 @@ Gb"0F_%"1&#XD6"#B1qiGGG^V6GZ#ZkijB5'RjB4S^5I61&$Ni:Xh=4S_9KYN;c9MUZPn/h,c]oCLUmg
 EI
 "###;
         let mut lexer = Lexer::new(data);
-        assert!(inline_image(&mut lexer, &NoResolve).is_ok()); 
+        assert!(inline_image(&mut lexer, &NoResolve).is_ok());
     }
 }

--- a/pdf/src/font.rs
+++ b/pdf/src/font.rs
@@ -1,28 +1,28 @@
 use crate as pdf;
-use crate::object::*;
-use crate::primitive::*;
-use crate::error::*;
 use crate::encoding::Encoding;
-use std::collections::HashMap;
-use std::fmt::Write;
-use crate::parser::{Lexer, parse_with_lexer, ParseFlags};
-use std::convert::TryInto;
-use std::sync::Arc;
-use istring::SmallString;
+use crate::error::*;
+use crate::object::*;
+use crate::parser::{parse_with_lexer, Lexer, ParseFlags};
+use crate::primitive::*;
 use datasize::DataSize;
+use istring::SmallString;
 use itertools::Itertools;
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::fmt::Write;
+use std::sync::Arc;
 
 #[allow(non_upper_case_globals, dead_code)]
 mod flags {
-    pub const FixedPitch: u32    = 1 << 0;
-    pub const Serif: u32         = 1 << 1;
-    pub const Symbolic: u32      = 1 << 2;
-    pub const Script: u32        = 1 << 3;
-    pub const Nonsymbolic: u32   = 1 << 5;
-    pub const Italic: u32        = 1 << 6;
-    pub const AllCap: u32        = 1 << 16;
-    pub const SmallCap: u32      = 1 << 17;
-    pub const ForceBold: u32     = 1 << 18;
+    pub const FixedPitch: u32 = 1 << 0;
+    pub const Serif: u32 = 1 << 1;
+    pub const Symbolic: u32 = 1 << 2;
+    pub const Script: u32 = 1 << 3;
+    pub const Nonsymbolic: u32 = 1 << 5;
+    pub const Italic: u32 = 1 << 6;
+    pub const AllCap: u32 = 1 << 16;
+    pub const SmallCap: u32 = 1 << 17;
+    pub const ForceBold: u32 = 1 << 18;
 }
 
 #[derive(Object, ObjectWrite, Debug, Copy, Clone, DataSize, DeepClone)]
@@ -48,7 +48,7 @@ pub struct Font {
     pub to_unicode: Option<RcRef<Stream<()>>>,
 
     /// other keys not mapped in other places. May change over time without notice, and adding things probably will break things. So don't expect this to be part of the stable API
-    pub _other: Dictionary
+    pub _other: Dictionary,
 }
 
 #[derive(Debug, DataSize, DeepClone)]
@@ -64,23 +64,25 @@ pub enum FontData {
 #[derive(Debug, DataSize, DeepClone)]
 pub enum CidToGidMap {
     Identity,
-    Table(Vec<u16>)
+    Table(Vec<u16>),
 }
 impl Object for CidToGidMap {
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         match p {
-            Primitive::Name(name) if name == "Identity" => {
-                Ok(CidToGidMap::Identity)
-            }
+            Primitive::Name(name) if name == "Identity" => Ok(CidToGidMap::Identity),
             p @ Primitive::Stream(_) | p @ Primitive::Reference(_) => {
                 let stream: Stream<()> = Stream::from_primitive(p, resolve)?;
                 let data = stream.data(resolve)?;
-                Ok(CidToGidMap::Table(data.chunks(2).map(|c| (c[0] as u16) << 8 | c[1] as u16).collect()))
-            },
+                Ok(CidToGidMap::Table(
+                    data.chunks(2)
+                        .map(|c| (c[0] as u16) << 8 | c[1] as u16)
+                        .collect(),
+                ))
+            }
             p => Err(PdfError::UnexpectedPrimitive {
                 expected: "/Identity or Stream",
-                found: p.get_debug_name()
-            })
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
@@ -90,7 +92,11 @@ impl ObjectWrite for CidToGidMap {
             CidToGidMap::Identity => Ok(Name::from("Identity").into()),
             CidToGidMap::Table(ref table) => {
                 let mut data = Vec::with_capacity(table.len() * 2);
-                data.extend(table.iter().flat_map(|&v| <[u8; 2]>::into_iter(v.to_be_bytes())));
+                data.extend(
+                    table
+                        .iter()
+                        .flat_map(|&v| <[u8; 2]>::into_iter(v.to_be_bytes())),
+                );
                 Stream::new((), data).to_primitive(update)
             }
         }
@@ -101,7 +107,10 @@ impl Object for Font {
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         let mut dict = p.resolve(resolve)?.into_dictionary()?;
 
-        let subtype = t!(FontType::from_primitive(dict.require("Font", "Subtype")?, resolve));
+        let subtype = t!(FontType::from_primitive(
+            dict.require("Font", "Subtype")?,
+            resolve
+        ));
 
         // BaseFont is required for all FontTypes except Type3
         dict.expect("Font", "Type", "Font", true)?;
@@ -109,17 +118,22 @@ impl Object for Font {
         let base_font = match (base_font_primitive, subtype) {
             (Some(name), _) => Some(t!(t!(name.clone().resolve(resolve)).into_name(), name)),
             (None, FontType::Type3) => None,
-            (_, _) => return Err(PdfError::MissingEntry {
-                typ: "Font",
-                field: "BaseFont".to_string()
-            })
+            (_, _) => {
+                return Err(PdfError::MissingEntry {
+                    typ: "Font",
+                    field: "BaseFont".to_string(),
+                })
+            }
         };
 
-        let encoding = dict.remove("Encoding").map(|p| Object::from_primitive(p, resolve)).transpose()?;
+        let encoding = dict
+            .remove("Encoding")
+            .map(|p| Object::from_primitive(p, resolve))
+            .transpose()?;
 
         let to_unicode = match dict.remove("ToUnicode") {
             Some(p) => Some(Object::from_primitive(p, resolve)?),
-            None => None
+            None => None,
         };
         let _other = dict.clone();
         let data = match subtype {
@@ -128,16 +142,16 @@ impl Object for Font {
             FontType::TrueType => FontData::TrueType(TFont::from_dict(dict, resolve)?),
             FontType::CIDFontType0 => FontData::CIDFontType0(CIDFont::from_dict(dict, resolve)?),
             FontType::CIDFontType2 => FontData::CIDFontType2(CIDFont::from_dict(dict, resolve)?),
-            _ => FontData::Other(dict)
+            _ => FontData::Other(dict),
         };
-        
+
         Ok(Font {
             subtype,
             name: base_font,
             data,
             encoding,
             to_unicode,
-            _other
+            _other,
         })
     }
 }
@@ -149,7 +163,7 @@ impl ObjectWrite for Font {
             FontData::Type0(ref d) => d.to_dict(update)?,
             FontData::Other(ref dict) => dict.clone(),
         };
-        
+
         if let Some(ref to_unicode) = self.to_unicode {
             dict.insert("ToUnicode", to_unicode.to_primitive(update)?);
         }
@@ -166,7 +180,7 @@ impl ObjectWrite for Font {
             FontData::TrueType(_) => FontType::TrueType,
             FontData::CIDFontType0(_) => FontType::CIDFontType0,
             FontData::CIDFontType2(_) => FontType::CIDFontType2,
-            FontData::Other(_) => bail!("unimplemented")
+            FontData::Other(_) => bail!("unimplemented"),
         };
         dict.insert("Subtype", subtype.to_primitive(update)?);
         dict.insert("Type", Name::from("Font"));
@@ -175,36 +189,40 @@ impl ObjectWrite for Font {
     }
 }
 
-
 #[derive(Debug)]
 pub struct Widths {
     values: Vec<f32>,
     default: f32,
-    first_char: usize
+    first_char: usize,
 }
 impl Widths {
     pub fn get(&self, cid: usize) -> f32 {
         if cid < self.first_char {
             self.default
         } else {
-            self.values.get(cid - self.first_char).cloned().unwrap_or(self.default)
+            self.values
+                .get(cid - self.first_char)
+                .cloned()
+                .unwrap_or(self.default)
         }
     }
     fn new(default: f32) -> Widths {
         Widths {
             default,
             values: Vec::new(),
-            first_char: 0
+            first_char: 0,
         }
     }
     fn ensure_cid(&mut self, cid: usize) {
-        if let Some(offset) = cid.checked_sub(self.first_char) { // cid may be < first_char
+        if let Some(offset) = cid.checked_sub(self.first_char) {
+            // cid may be < first_char
             // reserve difference of offset to capacity
             // if enough capacity to cover offset, saturates to zero, and reserve will do nothing
-            self.values.reserve(offset.saturating_sub(self.values.capacity()));
+            self.values
+                .reserve(offset.saturating_sub(self.values.capacity()));
         }
     }
-    #[allow(clippy::float_cmp)]  // TODO
+    #[allow(clippy::float_cmp)] // TODO
     fn set(&mut self, cid: usize, width: f32) {
         self._set(cid, width);
         debug_assert_eq!(self.get(cid), width);
@@ -224,7 +242,8 @@ impl Widths {
         }
 
         if cid < self.first_char {
-            self.values.splice(0 .. 0, repeat(self.default).take(self.first_char - cid));
+            self.values
+                .splice(0..0, repeat(self.default).take(self.first_char - cid));
             self.first_char = cid;
             self.values[0] = width;
             return;
@@ -232,7 +251,8 @@ impl Widths {
 
         if cid > self.values.len() + self.first_char {
             self.ensure_cid(cid);
-            self.values.extend(repeat(self.default).take(cid - self.first_char - self.values.len()));
+            self.values
+                .extend(repeat(self.default).take(cid - self.first_char - self.values.len()));
             self.values.push(width);
             return;
         }
@@ -243,20 +263,35 @@ impl Widths {
 impl Font {
     pub fn embedded_data(&self, resolve: &impl Resolve) -> Option<Result<Arc<[u8]>>> {
         match self.data {
-            FontData::Type0(ref t) => t.descendant_fonts.get(0).and_then(|f| f.embedded_data(resolve)),
-            FontData::CIDFontType0(ref c) | FontData::CIDFontType2(ref c) => c.font_descriptor.data(resolve),
-            FontData::Type1(ref t) | FontData::TrueType(ref t) => t.font_descriptor.as_ref().and_then(|d| d.data(resolve)),
-            _ => None
+            FontData::Type0(ref t) => t
+                .descendant_fonts
+                .get(0)
+                .and_then(|f| f.embedded_data(resolve)),
+            FontData::CIDFontType0(ref c) | FontData::CIDFontType2(ref c) => {
+                c.font_descriptor.data(resolve)
+            }
+            FontData::Type1(ref t) | FontData::TrueType(ref t) => {
+                t.font_descriptor.as_ref().and_then(|d| d.data(resolve))
+            }
+            _ => None,
         }
     }
     pub fn is_cid(&self) -> bool {
-        matches!(self.data, FontData::Type0(_) | FontData::CIDFontType0(_) | FontData::CIDFontType2(_))
+        matches!(
+            self.data,
+            FontData::Type0(_) | FontData::CIDFontType0(_) | FontData::CIDFontType2(_)
+        )
     }
     pub fn cid_to_gid_map(&self) -> Option<&CidToGidMap> {
         match self.data {
-            FontData::Type0(ref inner) => inner.descendant_fonts.get(0).and_then(|f| f.cid_to_gid_map()),
-            FontData::CIDFontType0(ref f) | FontData::CIDFontType2(ref f) => f.cid_to_gid_map.as_ref(),
-            _ => None
+            FontData::Type0(ref inner) => inner
+                .descendant_fonts
+                .get(0)
+                .and_then(|f| f.cid_to_gid_map()),
+            FontData::CIDFontType0(ref f) | FontData::CIDFontType2(ref f) => {
+                f.cid_to_gid_map.as_ref()
+            }
+            _ => None,
         }
     }
     pub fn encoding(&self) -> Option<&Encoding> {
@@ -266,21 +301,23 @@ impl Font {
         match self.data {
             FontData::Type1(ref info) => Some(info),
             FontData::TrueType(ref info) => Some(info),
-            _ => None
+            _ => None,
         }
     }
     pub fn widths(&self, resolve: &impl Resolve) -> Result<Option<Widths>> {
         match self.data {
             FontData::Type0(ref t0) => t0.descendant_fonts[0].widths(resolve),
-            FontData::Type1(ref info) | FontData::TrueType(ref info) => {
-                match *info {
-                    TFont { first_char: Some(first), ref widths, .. } => Ok(Some(Widths {
-                        default: 0.0,
-                        first_char: first as usize,
-                        values: widths.as_ref().cloned().unwrap_or_default()
-                    })),
-                    _ => Ok(None)
-                }
+            FontData::Type1(ref info) | FontData::TrueType(ref info) => match *info {
+                TFont {
+                    first_char: Some(first),
+                    ref widths,
+                    ..
+                } => Ok(Some(Widths {
+                    default: 0.0,
+                    first_char: first as usize,
+                    values: widths.as_ref().cloned().unwrap_or_default(),
+                })),
+                _ => Ok(None),
             },
             FontData::CIDFontType0(ref cid) | FontData::CIDFontType2(ref cid) => {
                 let mut widths = Widths::new(cid.default_width);
@@ -293,152 +330,159 @@ impl Font {
                             for (i, w) in array.iter().enumerate() {
                                 widths.set(c1 + i, w.as_number()?);
                             }
-                        },
-                        Some(&Primitive::Reference(r)) => {
-                            match resolve.resolve(r)? {
-                                Primitive::Array(array) => {
-                                    widths.ensure_cid(c1 + array.len() - 1);
-                                    for (i, w) in array.iter().enumerate() {
-                                        widths.set(c1 + i, w.as_number()?);
-                                    }
-                                }
-                                p => return Err(PdfError::Other { msg: format!("unexpected primitive in W array: {:?}", p) })
-                            }
                         }
+                        Some(&Primitive::Reference(r)) => match resolve.resolve(r)? {
+                            Primitive::Array(array) => {
+                                widths.ensure_cid(c1 + array.len() - 1);
+                                for (i, w) in array.iter().enumerate() {
+                                    widths.set(c1 + i, w.as_number()?);
+                                }
+                            }
+                            p => {
+                                return Err(PdfError::Other {
+                                    msg: format!("unexpected primitive in W array: {:?}", p),
+                                })
+                            }
+                        },
                         Some(&Primitive::Integer(c2)) => {
                             let w = try_opt!(iter.next()).as_number()?;
-                            for c in c1 ..= (c2 as usize) {
+                            for c in c1..=(c2 as usize) {
                                 widths.set(c, w);
                             }
-                        },
-                        p => return Err(PdfError::Other { msg: format!("unexpected primitive in W array: {:?}", p) })
+                        }
+                        p => {
+                            return Err(PdfError::Other {
+                                msg: format!("unexpected primitive in W array: {:?}", p),
+                            })
+                        }
                     }
                 }
                 Ok(Some(widths))
-            },
-            _ => Ok(None)
+            }
+            _ => Ok(None),
         }
     }
     pub fn to_unicode(&self, resolve: &impl Resolve) -> Option<Result<ToUnicodeMap>> {
-        self.to_unicode.as_ref().map(|s| (**s).data(resolve).and_then(|d| parse_cmap(&d)))
+        self.to_unicode
+            .as_ref()
+            .map(|s| (**s).data(resolve).and_then(|d| parse_cmap(&d)))
     }
 }
 #[derive(Object, ObjectWrite, Debug, DataSize, DeepClone)]
 pub struct TFont {
-    #[pdf(key="BaseFont")]
+    #[pdf(key = "BaseFont")]
     pub base_font: Option<Name>,
 
     /// per spec required, but some files lack it.
-    #[pdf(key="FirstChar")]
+    #[pdf(key = "FirstChar")]
     pub first_char: Option<i32>,
 
     /// same
-    #[pdf(key="LastChar")]
+    #[pdf(key = "LastChar")]
     pub last_char: Option<i32>,
 
-    #[pdf(key="Widths")]
+    #[pdf(key = "Widths")]
     pub widths: Option<Vec<f32>>,
 
-    #[pdf(key="FontDescriptor")]
-    pub font_descriptor: Option<FontDescriptor>
+    #[pdf(key = "FontDescriptor")]
+    pub font_descriptor: Option<FontDescriptor>,
 }
 
 #[derive(Object, ObjectWrite, Debug, DataSize, DeepClone)]
 pub struct Type0Font {
-    #[pdf(key="DescendantFonts")]
+    #[pdf(key = "DescendantFonts")]
     pub descendant_fonts: Vec<MaybeRef<Font>>,
 
-    #[pdf(key="ToUnicode")]
+    #[pdf(key = "ToUnicode")]
     pub to_unicode: Option<RcRef<Stream<()>>>,
 }
 
 #[derive(Object, ObjectWrite, Debug, DataSize, DeepClone)]
 pub struct CIDFont {
-    #[pdf(key="CIDSystemInfo")]
+    #[pdf(key = "CIDSystemInfo")]
     pub system_info: Dictionary,
 
-    #[pdf(key="FontDescriptor")]
+    #[pdf(key = "FontDescriptor")]
     pub font_descriptor: FontDescriptor,
 
-    #[pdf(key="DW", default="1000.")]
+    #[pdf(key = "DW", default = "1000.")]
     pub default_width: f32,
 
-    #[pdf(key="W")]
+    #[pdf(key = "W")]
     pub widths: Vec<Primitive>,
 
-    #[pdf(key="CIDToGIDMap")]
+    #[pdf(key = "CIDToGIDMap")]
     pub cid_to_gid_map: Option<CidToGidMap>,
 
     #[pdf(other)]
-    pub _other: Dictionary
+    pub _other: Dictionary,
 }
-
 
 #[derive(Object, ObjectWrite, Debug, DataSize, DeepClone)]
 pub struct FontDescriptor {
-    #[pdf(key="FontName")]
+    #[pdf(key = "FontName")]
     pub font_name: Name,
 
-    #[pdf(key="FontFamily")]
+    #[pdf(key = "FontFamily")]
     pub font_family: Option<PdfString>,
 
-    #[pdf(key="FontStretch")]
+    #[pdf(key = "FontStretch")]
     pub font_stretch: Option<FontStretch>,
 
-    #[pdf(key="FontWeight")]
+    #[pdf(key = "FontWeight")]
     pub font_weight: Option<f32>,
 
-    #[pdf(key="Flags")]
+    #[pdf(key = "Flags")]
     pub flags: u32,
 
-    #[pdf(key="FontBBox")]
-    pub font_bbox: Rect,
+    #[pdf(key = "FontBBox")]
+    pub font_bbox: Rectangle,
 
-    #[pdf(key="ItalicAngle")]
+    #[pdf(key = "ItalicAngle")]
     pub italic_angle: f32,
 
     // required as per spec, but still missing in some cases
-    #[pdf(key="Ascent")]
+    #[pdf(key = "Ascent")]
     pub ascent: Option<f32>,
 
-    #[pdf(key="Descent")]
+    #[pdf(key = "Descent")]
     pub descent: Option<f32>,
 
-    #[pdf(key="Leading", default="0.")]
+    #[pdf(key = "Leading", default = "0.")]
     pub leading: f32,
 
-    #[pdf(key="CapHeight")]
+    #[pdf(key = "CapHeight")]
     pub cap_height: Option<f32>,
 
-    #[pdf(key="XHeight", default="0.")]
+    #[pdf(key = "XHeight", default = "0.")]
     pub xheight: f32,
 
-    #[pdf(key="StemV", default="0.")]
+    #[pdf(key = "StemV", default = "0.")]
     pub stem_v: f32,
 
-    #[pdf(key="StemH", default="0.")]
+    #[pdf(key = "StemH", default = "0.")]
     pub stem_h: f32,
 
-    #[pdf(key="AvgWidth", default="0.")]
+    #[pdf(key = "AvgWidth", default = "0.")]
     pub avg_width: f32,
 
-    #[pdf(key="MaxWidth", default="0.")]
+    #[pdf(key = "MaxWidth", default = "0.")]
     pub max_width: f32,
 
-    #[pdf(key="MissingWidth", default="0.")]
+    #[pdf(key = "MissingWidth", default = "0.")]
     pub missing_width: f32,
 
-    #[pdf(key="FontFile")]
+    #[pdf(key = "FontFile")]
     pub font_file: Option<RcRef<Stream<()>>>,
 
-    #[pdf(key="FontFile2")]
+    #[pdf(key = "FontFile2")]
     pub font_file2: Option<RcRef<Stream<()>>>,
 
-    #[pdf(key="FontFile3")]
+    #[pdf(key = "FontFile3")]
     pub font_file3: Option<RcRef<Stream<FontStream3>>>,
 
-    #[pdf(key="CharSet")]
-    pub char_set: Option<PdfString>
+    #[pdf(key = "CharSet")]
+    pub char_set: Option<PdfString>,
 }
 impl FontDescriptor {
     pub fn data(&self, resolve: &impl Resolve) -> Option<Result<Arc<[u8]>>> {
@@ -455,19 +499,21 @@ impl FontDescriptor {
 }
 
 #[derive(Object, ObjectWrite, Debug, Clone, DataSize, DeepClone)]
-#[pdf(key="Subtype")]
+#[pdf(key = "Subtype")]
 pub enum FontTypeExt {
     Type1C,
     CIDFontType0C,
-    OpenType
+    OpenType,
 }
 #[derive(Object, ObjectWrite, Debug, Clone, DataSize, DeepClone)]
 pub struct FontStream3 {
-    #[pdf(key="Subtype")]
-    pub subtype: FontTypeExt
+    #[pdf(key = "Subtype")]
+    pub subtype: FontTypeExt,
 }
 
-#[derive(Object, ObjectWrite, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, DataSize, DeepClone)]
+#[derive(
+    Object, ObjectWrite, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, DataSize, DeepClone,
+)]
 pub enum FontStretch {
     UltraCondensed,
     ExtraCondensed,
@@ -477,13 +523,13 @@ pub enum FontStretch {
     SemiExpanded,
     Expanded,
     ExtraExpanded,
-    UltraExpanded
+    UltraExpanded,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct ToUnicodeMap {
     // todo: reduce allocations
-    inner: HashMap<u16, SmallString>
+    inner: HashMap<u16, SmallString>,
 }
 impl ToUnicodeMap {
     pub fn new() -> Self {
@@ -492,8 +538,10 @@ impl ToUnicodeMap {
     /// Create a new ToUnicodeMap from key/value pairs.
     ///
     /// subject to change
-    pub fn create(iter: impl Iterator<Item=(u16, SmallString)>) -> Self {
-        ToUnicodeMap { inner: iter.collect() }
+    pub fn create(iter: impl Iterator<Item = (u16, SmallString)>) -> Self {
+        ToUnicodeMap {
+            inner: iter.collect(),
+        }
     }
     pub fn get(&self, gid: u16) -> Option<&str> {
         self.inner.get(&gid).map(|s| s.as_str())
@@ -501,8 +549,10 @@ impl ToUnicodeMap {
     pub fn insert(&mut self, gid: u16, unicode: SmallString) {
         self.inner.insert(gid, unicode);
     }
-    pub fn iter(&self) -> impl Iterator<Item=(u16, &str)> {
-        self.inner.iter().map(|(&gid, unicode)| (gid, unicode.as_str()))
+    pub fn iter(&self) -> impl Iterator<Item = (u16, &str)> {
+        self.inner
+            .iter()
+            .map(|(&gid, unicode)| (gid, unicode.as_str()))
     }
     pub fn len(&self) -> usize {
         self.inner.len()
@@ -517,7 +567,10 @@ impl ToUnicodeMap {
 pub fn utf16be_to_char(
     data: &[u8],
 ) -> impl Iterator<Item = std::result::Result<char, std::char::DecodeUtf16Error>> + '_ {
-    char::decode_utf16(data.chunks_exact(2).map(|w| u16::from_be_bytes([w[0], w[1]])))
+    char::decode_utf16(
+        data.chunks_exact(2)
+            .map(|w| u16::from_be_bytes([w[0], w[1]])),
+    )
 }
 /// converts UTF16-BE to a string replacing illegal/unknown characters
 pub fn utf16be_to_string_lossy(data: &[u8]) -> String {
@@ -568,7 +621,11 @@ fn parse_cmap(data: &[u8]) -> Result<ToUnicodeMap> {
                     break;
                 }
                 let b = parse_with_lexer(&mut lexer, &NoResolve, ParseFlags::STRING);
-                let c = parse_with_lexer(&mut lexer, &NoResolve, ParseFlags::STRING | ParseFlags::ARRAY);
+                let c = parse_with_lexer(
+                    &mut lexer,
+                    &NoResolve,
+                    ParseFlags::STRING | ParseFlags::ARRAY,
+                );
                 match (a, b, c) {
                     (
                         Ok(Primitive::String(cid_start_data)),
@@ -635,9 +692,12 @@ fn write_unicode(out: &mut String, unicode: &str) {
 }
 pub fn write_cmap(map: &ToUnicodeMap) -> String {
     let mut buf = String::new();
-    let mut list: Vec<(u16, &str)> = map.inner.iter().map(|(&cid, s)| (cid, s.as_str())).collect();
+    let mut list: Vec<(u16, &str)> = map
+        .inner
+        .iter()
+        .map(|(&cid, s)| (cid, s.as_str()))
+        .collect();
     list.sort();
-
 
     let mut remaining = &list[..];
     let blocks = std::iter::from_fn(move || {
@@ -645,8 +705,12 @@ pub fn write_cmap(map: &ToUnicodeMap) -> String {
             return None;
         }
         let first_cid = remaining[0].0;
-        let seq_len = remaining.iter().enumerate().take_while(|&(i, &(cid, _))| cid == first_cid + i as u16).count();
-        
+        let seq_len = remaining
+            .iter()
+            .enumerate()
+            .take_while(|&(i, &(cid, _))| cid == first_cid + i as u16)
+            .count();
+
         let (block, tail) = remaining.split_at(seq_len);
         remaining = tail;
         Some(block)
@@ -678,7 +742,7 @@ pub fn write_cmap(map: &ToUnicodeMap) -> String {
                     write_unicode(&mut buf, u);
                 }
                 writeln!(buf, "]").unwrap();
-            }    
+            }
             writeln!(buf, "endbfrange").unwrap();
         }
     }
@@ -689,7 +753,7 @@ pub fn write_cmap(map: &ToUnicodeMap) -> String {
 #[cfg(test)]
 mod tests {
 
-    use crate::font::{utf16be_to_string, utf16be_to_char, utf16be_to_string_lossy};
+    use crate::font::{utf16be_to_char, utf16be_to_string, utf16be_to_string_lossy};
     #[test]
     fn utf16be_to_string_quick() {
         let v = vec![0x20, 0x09];
@@ -702,8 +766,8 @@ mod tests {
     fn test_to_char() {
         // 𝄞mus<invalid>ic<invalid>
         let v = [
-            0xD8, 0x34, 0xDD, 0x1E, 0x00, 0x6d, 0x00, 0x75, 0x00, 0x73, 0xDD, 0x1E, 0x00, 0x69, 0x00,
-            0x63, 0xD8, 0x34,
+            0xD8, 0x34, 0xDD, 0x1E, 0x00, 0x6d, 0x00, 0x75, 0x00, 0x73, 0xDD, 0x1E, 0x00, 0x69,
+            0x00, 0x63, 0xD8, 0x34,
         ];
 
         assert_eq!(

--- a/pdf/src/object/mod.rs
+++ b/pdf/src/object/mod.rs
@@ -2,31 +2,31 @@
 //!
 //! Some of the structs are incomplete (missing fields that are in the PDF references).
 
-mod types;
-mod stream;
 mod color;
 mod function;
+mod stream;
+mod types;
 
-pub use self::types::*;
-pub use self::stream::*;
 pub use self::color::*;
 pub use self::function::*;
+pub use self::stream::*;
+pub use self::types::*;
 pub use crate::file::PromisedRef;
 use crate::parser::ParseFlags;
 
-use crate::primitive::*;
-use crate::error::*;
 use crate::enc::*;
+use crate::error::*;
+use crate::primitive::*;
 
-use std::fmt;
-use std::marker::PhantomData;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::ops::{Deref, Range};
-use std::hash::{Hash, Hasher};
-use std::convert::TryInto;
 use datasize::DataSize;
 use itertools::Itertools;
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+use std::ops::{Deref, Range};
+use std::sync::Arc;
 
 pub type ObjNr = u64;
 pub type GenNr = u64;
@@ -56,15 +56,20 @@ impl ParseOptions {
     }
 }
 
-pub trait Resolve: {
+pub trait Resolve {
     fn resolve_flags(&self, r: PlainRef, flags: ParseFlags, depth: usize) -> Result<Primitive>;
     fn resolve(&self, r: PlainRef) -> Result<Primitive> {
         self.resolve_flags(r, ParseFlags::ANY, 16)
     }
-    fn get<T: Object+DataSize>(&self, r: Ref<T>) -> Result<RcRef<T>>;
+    fn get<T: Object + DataSize>(&self, r: Ref<T>) -> Result<RcRef<T>>;
     fn options(&self) -> &ParseOptions;
     fn stream_data(&self, id: PlainRef, range: Range<usize>) -> Result<Arc<[u8]>>;
-    fn get_data_or_decode(&self, id: PlainRef, range: Range<usize>, filters: &[StreamFilter]) -> Result<Arc<[u8]>>;
+    fn get_data_or_decode(
+        &self,
+        id: PlainRef,
+        range: Range<usize>,
+        filters: &[StreamFilter],
+    ) -> Result<Arc<[u8]>>;
 }
 
 pub struct NoResolve;
@@ -72,20 +77,24 @@ impl Resolve for NoResolve {
     fn resolve_flags(&self, _: PlainRef, _: ParseFlags, _: usize) -> Result<Primitive> {
         Err(PdfError::Reference)
     }
-    fn get<T: Object+DataSize>(&self, _r: Ref<T>) -> Result<RcRef<T>> {
+    fn get<T: Object + DataSize>(&self, _r: Ref<T>) -> Result<RcRef<T>> {
         Err(PdfError::Reference)
     }
     fn options(&self) -> &ParseOptions {
         static STRICT: ParseOptions = ParseOptions::strict();
         &STRICT
     }
-    fn get_data_or_decode(&self, _: PlainRef, _: Range<usize>, _: &[StreamFilter]) -> Result<Arc<[u8]>> {
+    fn get_data_or_decode(
+        &self,
+        _: PlainRef,
+        _: Range<usize>,
+        _: &[StreamFilter],
+    ) -> Result<Arc<[u8]>> {
         Err(PdfError::Reference)
     }
     fn stream_data(&self, id: PlainRef, range: Range<usize>) -> Result<Arc<[u8]>> {
         Err(PdfError::Reference)
     }
-
 }
 
 /// A PDF Object
@@ -96,8 +105,14 @@ pub trait Object: Sized + Sync + Send + 'static {
 
 pub trait Cloner: Updater + Resolve {
     fn clone_plainref(&mut self, old: PlainRef) -> Result<PlainRef>;
-    fn clone_ref<T: DeepClone + Object + DataSize + ObjectWrite>(&mut self, old: Ref<T>) -> Result<Ref<T>>;
-    fn clone_rcref<T: DeepClone + ObjectWrite + DataSize>(&mut self, old: &RcRef<T>) -> Result<RcRef<T>>;
+    fn clone_ref<T: DeepClone + Object + DataSize + ObjectWrite>(
+        &mut self,
+        old: Ref<T>,
+    ) -> Result<Ref<T>>;
+    fn clone_rcref<T: DeepClone + ObjectWrite + DataSize>(
+        &mut self,
+        old: &RcRef<T>,
+    ) -> Result<RcRef<T>>;
     fn clone_shared<T: DeepClone>(&mut self, old: &Shared<T>) -> Result<Shared<T>>;
 }
 
@@ -114,10 +129,18 @@ pub trait Updater {
 
 pub struct NoUpdate;
 impl Updater for NoUpdate {
-    fn create<T: ObjectWrite>(&mut self, _obj: T) -> Result<RcRef<T>> { panic!() }
-    fn update<T: ObjectWrite>(&mut self, _old: PlainRef, _obj: T) -> Result<RcRef<T>> { panic!() }
-    fn promise<T: Object>(&mut self) -> PromisedRef<T> { panic!() }
-    fn fulfill<T: ObjectWrite>(&mut self, _promise: PromisedRef<T>, _obj: T) -> Result<RcRef<T>> { panic!() }
+    fn create<T: ObjectWrite>(&mut self, _obj: T) -> Result<RcRef<T>> {
+        panic!()
+    }
+    fn update<T: ObjectWrite>(&mut self, _old: PlainRef, _obj: T) -> Result<RcRef<T>> {
+        panic!()
+    }
+    fn promise<T: Object>(&mut self) -> PromisedRef<T> {
+        panic!()
+    }
+    fn fulfill<T: ObjectWrite>(&mut self, _promise: PromisedRef<T>, _obj: T) -> Result<RcRef<T>> {
+        panic!()
+    }
 }
 
 pub trait ObjectWrite {
@@ -144,8 +167,8 @@ pub trait Trace {
 // TODO move to primitive.rs
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, DataSize)]
 pub struct PlainRef {
-    pub id:     ObjNr,
-    pub gen:    GenNr,
+    pub id: ObjNr,
+    pub gen: GenNr,
 }
 impl Object for PlainRef {
     fn from_primitive(p: Primitive, _: &impl Resolve) -> Result<Self> {
@@ -167,8 +190,8 @@ impl DeepClone for PlainRef {
 
 #[derive(DataSize)]
 pub struct Ref<T> {
-    inner:      PlainRef,
-    _marker:    PhantomData<T>
+    inner: PlainRef,
+    _marker: PhantomData<T>,
 }
 impl<T> Clone for Ref<T> {
     fn clone(&self) -> Ref<T> {
@@ -181,19 +204,22 @@ impl<T> Ref<T> {
     pub fn new(inner: PlainRef) -> Ref<T> {
         Ref {
             inner,
-            _marker:    PhantomData,
+            _marker: PhantomData,
         }
     }
     pub fn from_id(id: ObjNr) -> Ref<T> {
         Ref {
-            inner:      PlainRef {id, gen: 0},
-            _marker:    PhantomData,
+            inner: PlainRef { id, gen: 0 },
+            _marker: PhantomData,
         }
     }
     pub fn get_inner(&self) -> PlainRef {
         self.inner
     }
-    pub fn upcast<U>(self) -> Ref<U> where T: SubType<U> {
+    pub fn upcast<U>(self) -> Ref<U>
+    where
+        T: SubType<U>,
+    {
         Ref::new(self.inner)
     }
 }
@@ -207,7 +233,7 @@ impl<T> ObjectWrite for Ref<T> {
         self.inner.to_primitive(update)
     }
 }
-impl<T: DeepClone+Object+DataSize+ObjectWrite> DeepClone for Ref<T> {
+impl<T: DeepClone + Object + DataSize + ObjectWrite> DeepClone for Ref<T> {
     fn deep_clone(&self, cloner: &mut impl Cloner) -> Result<Self> {
         cloner.clone_ref(*self)
     }
@@ -236,11 +262,10 @@ impl<T> Eq for Ref<T> {}
 
 pub type Shared<T> = Arc<T>;
 
-
 #[derive(Debug, DataSize)]
 pub struct RcRef<T> {
     inner: PlainRef,
-    data: Shared<T>
+    data: Shared<T>,
 }
 impl<T> From<RcRef<T>> for Primitive {
     fn from(value: RcRef<T>) -> Self {
@@ -268,7 +293,10 @@ impl<T: Object + std::fmt::Debug + DataSize> Object for RcRef<T> {
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         match p {
             Primitive::Reference(r) => resolve.get(Ref::new(r)),
-            p => Err(PdfError::UnexpectedPrimitive {expected: "Reference", found: p.get_debug_name()})
+            p => Err(PdfError::UnexpectedPrimitive {
+                expected: "Reference",
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
@@ -328,21 +356,21 @@ impl<T> MaybeRef<T> {
     pub fn as_ref(&self) -> Option<Ref<T>> {
         match *self {
             MaybeRef::Indirect(ref r) => Some(r.get_ref()),
-            _ => None
+            _ => None,
         }
     }
     pub fn data(&self) -> &Shared<T> {
         match *self {
             MaybeRef::Direct(ref t) => t,
-            MaybeRef::Indirect(ref r) => &r.data
+            MaybeRef::Indirect(ref r) => &r.data,
         }
     }
 }
-impl<T: Object+DataSize> Object for MaybeRef<T> {
+impl<T: Object + DataSize> Object for MaybeRef<T> {
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         Ok(match p {
             Primitive::Reference(r) => MaybeRef::Indirect(resolve.get(Ref::new(r))?),
-            p => MaybeRef::Direct(Shared::new(T::from_primitive(p, resolve)?))
+            p => MaybeRef::Direct(Shared::new(T::from_primitive(p, resolve)?)),
         })
     }
 }
@@ -350,7 +378,7 @@ impl<T: ObjectWrite> ObjectWrite for MaybeRef<T> {
     fn to_primitive(&self, update: &mut impl Updater) -> Result<Primitive> {
         match self {
             MaybeRef::Direct(ref inner) => inner.to_primitive(update),
-            MaybeRef::Indirect(r) => r.to_primitive(update)
+            MaybeRef::Indirect(r) => r.to_primitive(update),
         }
     }
 }
@@ -358,7 +386,7 @@ impl<T: DeepClone + std::fmt::Debug + DataSize + Object + ObjectWrite> DeepClone
     fn deep_clone(&self, cloner: &mut impl Cloner) -> Result<Self> {
         match *self {
             MaybeRef::Direct(ref old) => cloner.clone_shared(old).map(MaybeRef::Direct),
-            MaybeRef::Indirect(ref old) => cloner.clone_rcref(old).map(MaybeRef::Indirect)
+            MaybeRef::Indirect(ref old) => cloner.clone_rcref(old).map(MaybeRef::Indirect),
         }
     }
 }
@@ -367,7 +395,7 @@ impl<T> Deref for MaybeRef<T> {
     fn deref(&self) -> &T {
         match *self {
             MaybeRef::Direct(ref t) => t,
-            MaybeRef::Indirect(ref r) => r
+            MaybeRef::Indirect(ref r) => r,
         }
     }
 }
@@ -375,7 +403,7 @@ impl<T> Clone for MaybeRef<T> {
     fn clone(&self) -> Self {
         match *self {
             MaybeRef::Direct(ref rc) => MaybeRef::Direct(rc.clone()),
-            MaybeRef::Indirect(ref r) => MaybeRef::Indirect(r.clone())
+            MaybeRef::Indirect(ref r) => MaybeRef::Indirect(r.clone()),
         }
     }
 }
@@ -383,7 +411,7 @@ impl<T> Trace for MaybeRef<T> {
     fn trace(&self, cb: &mut impl FnMut(PlainRef)) {
         match *self {
             MaybeRef::Indirect(ref rc) => rc.trace(cb),
-            MaybeRef::Direct(_) => ()
+            MaybeRef::Direct(_) => (),
         }
     }
 }
@@ -401,7 +429,7 @@ impl<T> From<MaybeRef<T>> for Shared<T> {
     fn from(r: MaybeRef<T>) -> Shared<T> {
         match r {
             MaybeRef::Direct(rc) => rc,
-            MaybeRef::Indirect(r) => r.data
+            MaybeRef::Indirect(r) => r.data,
         }
     }
 }
@@ -409,7 +437,7 @@ impl<'a, T> From<&'a MaybeRef<T>> for Shared<T> {
     fn from(r: &'a MaybeRef<T>) -> Shared<T> {
         match r {
             MaybeRef::Direct(ref rc) => rc.clone(),
-            MaybeRef::Indirect(ref r) => r.data.clone()
+            MaybeRef::Indirect(ref r) => r.data.clone(),
         }
     }
 }
@@ -438,7 +466,7 @@ impl Object for i32 {
     fn from_primitive(p: Primitive, r: &impl Resolve) -> Result<Self> {
         match p {
             Primitive::Reference(id) => r.resolve(id)?.as_integer(),
-            p => p.as_integer()
+            p => p.as_integer(),
         }
     }
 }
@@ -452,7 +480,7 @@ impl Object for u32 {
     fn from_primitive(p: Primitive, r: &impl Resolve) -> Result<Self> {
         match p {
             Primitive::Reference(id) => r.resolve(id)?.as_u32(),
-            p => p.as_u32()
+            p => p.as_u32(),
         }
     }
 }
@@ -466,7 +494,7 @@ impl Object for usize {
     fn from_primitive(p: Primitive, r: &impl Resolve) -> Result<Self> {
         match p {
             Primitive::Reference(id) => Ok(r.resolve(id)?.as_u32()? as usize),
-            p => Ok(p.as_u32()? as usize)
+            p => Ok(p.as_u32()? as usize),
         }
     }
 }
@@ -480,7 +508,7 @@ impl Object for f32 {
     fn from_primitive(p: Primitive, r: &impl Resolve) -> Result<Self> {
         match p {
             Primitive::Reference(id) => r.resolve(id)?.as_number(),
-            p => p.as_number()
+            p => p.as_number(),
         }
     }
 }
@@ -494,7 +522,7 @@ impl Object for bool {
     fn from_primitive(p: Primitive, r: &impl Resolve) -> Result<Self> {
         match p {
             Primitive::Reference(id) => r.resolve(id)?.as_bool(),
-            p => p.as_bool()
+            p => p.as_bool(),
         }
     }
 }
@@ -509,7 +537,10 @@ impl Object for Dictionary {
         match p {
             Primitive::Dictionary(dict) => Ok(dict),
             Primitive::Reference(id) => Dictionary::from_primitive(r.resolve(id)?, r),
-            _ => Err(PdfError::UnexpectedPrimitive {expected: "Dictionary", found: p.get_debug_name()}),
+            _ => Err(PdfError::UnexpectedPrimitive {
+                expected: "Dictionary",
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
@@ -528,21 +559,17 @@ impl ObjectWrite for Name {
 impl<T: Object> Object for Vec<T> {
     /// Will try to convert `p` to `T` first, then try to convert `p` to Vec<T>
     fn from_primitive(p: Primitive, r: &impl Resolve) -> Result<Self> {
-        Ok(
-        match p {
-            Primitive::Array(_) => {
-                p.resolve(r)?.into_array()?
-                    .into_iter()
-                    .map(|p| T::from_primitive(p, r))
-                    .collect::<Result<Vec<T>>>()?
-            },
-            Primitive::Null => {
-                Vec::new()
-            }
+        Ok(match p {
+            Primitive::Array(_) => p
+                .resolve(r)?
+                .into_array()?
+                .into_iter()
+                .map(|p| T::from_primitive(p, r))
+                .collect::<Result<Vec<T>>>()?,
+            Primitive::Null => Vec::new(),
             Primitive::Reference(id) => Self::from_primitive(r.resolve(id)?, r)?,
-            _ => vec![T::from_primitive(p, r)?]
-        }
-        )
+            _ => vec![T::from_primitive(p, r)?],
+        })
     }
 }
 impl<T: ObjectWrite> ObjectWrite for Vec<T> {
@@ -581,7 +608,7 @@ impl Object for Data {
                 Vec::new()
             }
             Primitive::Reference(id) => Self::from_primitive(r.resolve(id)?, r)?,
-            _ => 
+            _ =>
         }
     }
 }*/
@@ -599,7 +626,12 @@ impl ObjectWrite for Primitive {
 impl DeepClone for Primitive {
     fn deep_clone(&self, cloner: &mut impl Cloner) -> Result<Self> {
         match *self {
-            Primitive::Array(ref parts) => Ok(Primitive::Array(parts.into_iter().map(|p| p.deep_clone(cloner)).try_collect()?)),
+            Primitive::Array(ref parts) => Ok(Primitive::Array(
+                parts
+                    .into_iter()
+                    .map(|p| p.deep_clone(cloner))
+                    .try_collect()?,
+            )),
             Primitive::Boolean(b) => Ok(Primitive::Boolean(b)),
             Primitive::Dictionary(ref dict) => Ok(Primitive::Dictionary(dict.deep_clone(cloner)?)),
             Primitive::Integer(i) => Ok(Primitive::Integer(i)),
@@ -608,7 +640,7 @@ impl DeepClone for Primitive {
             Primitive::Number(n) => Ok(Primitive::Number(n)),
             Primitive::Reference(r) => Ok(Primitive::Reference(r.deep_clone(cloner)?)),
             Primitive::Stream(ref s) => Ok(Primitive::Stream(s.deep_clone(cloner)?)),
-            Primitive::String(ref s) => Ok(Primitive::String(s.clone()))
+            Primitive::String(ref s) => Ok(Primitive::String(s.clone())),
         }
     }
 }
@@ -619,7 +651,7 @@ impl Trace for Primitive {
             Primitive::Reference(r) => cb(r),
             Primitive::Array(ref parts) => parts.iter().for_each(|p| p.trace(cb)),
             Primitive::Dictionary(ref dict) => dict.values().for_each(|p| p.trace(cb)),
-            _ => ()
+            _ => (),
         }
     }
 }
@@ -628,15 +660,18 @@ impl<V: Object> Object for HashMap<Name, V> {
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         match p {
             Primitive::Null => Ok(HashMap::new()),
-            Primitive::Dictionary (dict) => {
+            Primitive::Dictionary(dict) => {
                 let mut new = Self::new();
                 for (key, val) in dict.iter() {
                     new.insert(key.clone(), V::from_primitive(val.clone(), resolve)?);
                 }
                 Ok(new)
             }
-            Primitive::Reference (id) => HashMap::from_primitive(resolve.resolve(id)?, resolve),
-            p => Err(PdfError::UnexpectedPrimitive {expected: "Dictionary", found: p.get_debug_name()})
+            Primitive::Reference(id) => HashMap::from_primitive(resolve.resolve(id)?, resolve),
+            p => Err(PdfError::UnexpectedPrimitive {
+                expected: "Dictionary",
+                found: p.get_debug_name(),
+            }),
         }
     }
 }
@@ -655,7 +690,9 @@ impl<V: ObjectWrite> ObjectWrite for HashMap<Name, V> {
 }
 impl<V: DeepClone> DeepClone for HashMap<Name, V> {
     fn deep_clone(&self, cloner: &mut impl Cloner) -> Result<Self> {
-        self.iter().map(|(k, v)| Ok((k.clone(), v.deep_clone(cloner)?))).collect()
+        self.iter()
+            .map(|(k, v)| Ok((k.clone(), v.deep_clone(cloner)?)))
+            .collect()
     }
 }
 
@@ -666,14 +703,14 @@ impl<T: Object> Object for Option<T> {
             p => match T::from_primitive(p, resolve) {
                 Ok(p) => Ok(Some(p)),
                 // References to non-existing objects ought not to be an error
-                Err(PdfError::NullRef {..}) => Ok(None),
-                Err(PdfError::FreeObject {..}) => Ok(None),
+                Err(PdfError::NullRef { .. }) => Ok(None),
+                Err(PdfError::FreeObject { .. }) => Ok(None),
                 Err(e) if resolve.options().allow_error_in_option => {
                     warn!("ignoring {:?}", e);
                     Ok(None)
                 }
-                Err(e) => Err(e)
-            }
+                Err(e) => Err(e),
+            },
         }
     }
 }
@@ -681,7 +718,7 @@ impl<T: ObjectWrite> ObjectWrite for Option<T> {
     fn to_primitive(&self, update: &mut impl Updater) -> Result<Primitive> {
         match self {
             None => Ok(Primitive::Null),
-            Some(t) => t.to_primitive(update)
+            Some(t) => t.to_primitive(update),
         }
     }
 }
@@ -689,7 +726,7 @@ impl<T: DeepClone> DeepClone for Option<T> {
     fn deep_clone(&self, cloner: &mut impl Cloner) -> Result<Self> {
         match self {
             None => Ok(None),
-            Some(t) => t.deep_clone(cloner).map(Some)
+            Some(t) => t.deep_clone(cloner).map(Some),
         }
     }
 }
@@ -730,20 +767,34 @@ impl ObjectWrite for () {
 }
 impl Trace for () {}
 
-impl<T, U> Object for (T, U) where T: Object, U: Object {
+impl<T, U> Object for (T, U)
+where
+    T: Object,
+    U: Object,
+{
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
         let arr = p.resolve(resolve)?.into_array()?;
         if arr.len() != 2 {
             bail!("expected array of length 2 (found {})", arr.len());
         }
         let [a, b]: [Primitive; 2] = arr.try_into().unwrap();
-        Ok((T::from_primitive(a, resolve)?, U::from_primitive(b, resolve)?))
+        Ok((
+            T::from_primitive(a, resolve)?,
+            U::from_primitive(b, resolve)?,
+        ))
     }
 }
 
-impl<T, U> ObjectWrite for (T, U) where T: ObjectWrite, U: ObjectWrite {
+impl<T, U> ObjectWrite for (T, U)
+where
+    T: ObjectWrite,
+    U: ObjectWrite,
+{
     fn to_primitive(&self, update: &mut impl Updater) -> Result<Primitive> {
-        Ok(Primitive::Array(vec![self.0.to_primitive(update)?, self.1.to_primitive(update)?]))
+        Ok(Primitive::Array(vec![
+            self.0.to_primitive(update)?,
+            self.1.to_primitive(update)?,
+        ]))
     }
 }
 
@@ -770,7 +821,20 @@ macro_rules! deep_clone_simple {
         )*
     )
 }
-deep_clone_simple!(f32, i32, u32, bool, Name, (), Date, PdfString, Rect, u8, Arc<[u8]>, Vec<u16>);
+deep_clone_simple!(
+    f32,
+    i32,
+    u32,
+    bool,
+    Name,
+    (),
+    Date,
+    PdfString,
+    Rectangle,
+    u8,
+    Arc<[u8]>,
+    Vec<u16>
+);
 
 impl<A: DeepClone, B: DeepClone> DeepClone for (A, B) {
     fn deep_clone(&self, cloner: &mut impl Cloner) -> Result<Self> {


### PR DESCRIPTION
`content::Rect {x,y,width,height}` and `object::types::Rect {bottom,left,top,right}` are being used in conflicting ways.
Did research, presented in comments, and provided conversion between representations. Renamed to `ViewRect` and `Rectangle`, respectively, inline with ISO 32000-2-2020 spec.