### PR TITLE
fix build failure when running tests without cache feature

### DIFF
--- a/pdf/examples/content.rs
+++ b/pdf/examples/content.rs
@@ -14,6 +14,7 @@ use pdf::build::*;
 
 use pdf::primitive::PdfString;
 
+#[cfg(feature="cache")]
 fn main() -> Result<(), PdfError> {
     let path = PathBuf::from(env::args_os().nth(1).expect("no file given"));
     

--- a/pdf/examples/metadata.rs
+++ b/pdf/examples/metadata.rs
@@ -5,6 +5,7 @@ use pdf::file::{FileOptions};
 use pdf::object::{FieldDictionary, FieldType, Resolve};
 
 /// extract and print a PDF's metadata
+#[cfg(feature="cache")]
 fn main() -> Result<(), PdfError> {
     let path = args()
         .nth(1)

--- a/pdf/examples/names.rs
+++ b/pdf/examples/names.rs
@@ -60,6 +60,7 @@ fn walk_outline(r: &impl Resolve, mut node: RcRef<OutlineItem>, name_map: &impl 
     }
 }
 
+#[cfg(feature="cache")]
 fn main() {
     let path = args().nth(1).expect("no file given");
     println!("read: {}", path);

--- a/pdf/examples/other_page_content.rs
+++ b/pdf/examples/other_page_content.rs
@@ -8,6 +8,7 @@ use std::env::args;
 /// Extract data from a page entry that is under "other".
 /// This example looks for stikethroughs in the annotations entry
 /// and returns a Vec<Rect> for the bounds of the struckthrough text.
+#[cfg(feature="cache")]
 fn main() -> Result<(), PdfError> {
     let path = args()
         .nth(1)

--- a/pdf/examples/read.rs
+++ b/pdf/examples/read.rs
@@ -21,6 +21,7 @@ impl Log for VerboseLog {
     }
 }
 
+#[cfg(feature="cache")]
 fn main() -> Result<(), PdfError> {
     let path = args().nth(1).expect("no file given");
     println!("read: {}", path);

--- a/pdf/tests/integration.rs
+++ b/pdf/tests/integration.rs
@@ -21,7 +21,7 @@ macro_rules! run {
 #[test]
 fn open_file() {
     let _ = run!(FileOptions::uncached().open(file_path!("example.pdf")));
-    #[cfg(feature = "mmap")]
+    #[cfg(all(feature = "mmap", feature = "cache"))]
     let _ = run!({
         use memmap2::Mmap;
         let file = std::fs::File::open(file_path!("example.pdf")).expect("can't open file");


### PR DESCRIPTION
Not sure this is the proper fix, but submitting just in case it is

Fixes errors like:

```
error[E0599]: no function or associated item named `cached` found for struct `FileOptions` in the current scope
  --> examples/content.rs:13:33
   |
13 |     let mut file = FileOptions::cached().open(&path).unwrap();
   |                                 ^^^^^^
   |                                 |
   |                                 function or associated item not found in `FileOptions<'_, _, _>`
   |                                 help: there is a method with a similar name: `cache`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `pdf` due to previous error

```

Used to fail with:
`cargo test --all-targets --no-default-features --features dump`
`cargo test --all-targets --all-targets --no-default-features --features mmap`