### PR TITLE
fix InfoDict producer

### DIFF
--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -1797,7 +1797,7 @@ pub struct InfoDict {
     #[pdf(key="Creator")]
     pub creator: Option<PdfString>,
 
-    #[pdf(key="Author")]
+    #[pdf(key="Producer")]
     pub producer: Option<PdfString>,
 
     #[pdf(key="CreationDate")]


### PR DESCRIPTION
Hello ! 

I like your crate, but I found a bug in the InfoDict parser: when trying to get the producer in the InfoDict, it returned me the Author instead. 
 
The parser parsed the wrong key, probably a typo.