### PR TITLE
fix panic on malformed CIDToGID tables

### DIFF
--- a/pdf/src/font.rs
+++ b/pdf/src/font.rs
@@ -75,7 +75,7 @@ impl Object for CidToGidMap {
             p @ Primitive::Stream(_) | p @ Primitive::Reference(_) => {
                 let stream: Stream<()> = Stream::from_primitive(p, resolve)?;
                 let data = stream.data(resolve)?;
-                Ok(CidToGidMap::Table(data.chunks(2).map(|c| (c[0] as u16) << 8 | c[1] as u16).collect()))
+                Ok(CidToGidMap::Table(data.chunks_exact(2).map(|c| (c[0] as u16) << 8 | c[1] as u16).collect()))
             },
             p => Err(PdfError::UnexpectedPrimitive {
                 expected: "/Identity or Stream",


### PR DESCRIPTION
If the number of bytes in the stream is odd, indexing c[1] will result in an out of bounds access and will cause a panic.

This should not happen normally, since the spec says that this field should be a list of u16, but some malformed PDF trigger this bug.

This patch just ignores the last byte of odd length CidToGid tables, but we could check for odd lengths and return an error instead. Tell me what you prefer in this case. 