### PR TITLE
fix panic on 5 bits encryption key

### DIFF
--- a/pdf/src/crypt.rs
+++ b/pdf/src/crypt.rs
@@ -297,7 +297,13 @@ impl Decoder {
 
         let (key_bits, method) = match dict.v {
             1 => (40, CryptMethod::V2),
-            2 => (dict.bits, CryptMethod::V2),
+            2 => {
+                if dict.bits % 8 != 0 {
+                    err!(other!("invalid key length {}", dict.bits))
+                } else {
+                    (dict.bits, CryptMethod::V2)
+                }
+            },
             4 ..= 6 => {
                 let default = dict
                     .crypt_filters


### PR DESCRIPTION
Found this bug while fuzzing the crate. The spec says that /Length must be a multiple of 8 bits, but Decoder::from_password doesn't check for it, and panics if a length of 5 is passed.

Return an error if the key length is not a multiple of 8 bits.