### PR TITLE
fix panic on malformed trailer ID

### DIFF
--- a/pdf/src/file.rs
+++ b/pdf/src/file.rs
@@ -164,7 +164,12 @@ where
                     typ: "Trailer",
                     field: "ID".into(),
                 })?
-                .as_array()?[0]
+                .as_array()?
+                .get(0)
+                .ok_or(PdfError::MissingEntry {
+                    typ: "Trailer",
+                    field: "ID[0]".into()
+                })?
                 .as_string()?
                 .as_bytes();
 


### PR DESCRIPTION
Found this bug by fuzzing.

If the trailer ID is an empty array, `load_storage_and_trailer_password()` will panic when trying to access the first byte of an encrypted document.

Note that shouldn't happen on valid documents, the ID is supposed to be a an array of two byte strings.