### PR TITLE
Fixed wrongly typed checksum field in EmbeddedFileParamDict

### DIFF
--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -1556,7 +1556,7 @@ pub struct EmbeddedFileParamDict {
     mac: Option<Date>,
 
     #[pdf(key="CheckSum")]
-    checksum: Option<Date>,
+    checksum: Option<PdfString>,
 }
 
 #[derive(Object, Debug, Clone, DataSize)]


### PR DESCRIPTION
Fix for `resolver().get()` failing with following error when resolving a `Ref<Stream<EmbeddedFile>>`, if a `CheckSum` field is present:

    Shared, caused by
      Can't parse field params of struct Option < EmbeddedFileParamDict >, caused by
      Can't parse field checksum of struct Option < Date >, caused by
      Failed parsing date

ChekSum is defined as [16-byte string](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf), so `PdfString` should be a more fitting type.