### PR TITLE
Fix annotation missing keys in Annot Struct

### DIFF
--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -952,7 +952,7 @@ pub struct Annot {
     pub subtype: Name,
     
     #[pdf(key="Rect")]
-    pub rect: Rectangle,
+    pub rect: Option<Rectangle>,
 
     #[pdf(key="Contents")]
     pub contents: Option<PdfString>,
@@ -982,7 +982,7 @@ pub struct Annot {
     pub color: Option<Primitive>,
 
     #[pdf(key="InkList")]
-    pub inkList: Option<Primitive>,
+    pub ink_list: Option<Primitive>,
 
     #[pdf(other)]
     pub other: Dictionary,

--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -977,6 +977,15 @@ pub struct Annot {
 
     #[pdf(key="Border")]
     pub border: Option<Primitive>,
+
+    #[pdf(key="C")]
+    pub color: Option<Primitive>,
+
+    #[pdf(key="InkList")]
+    pub inkList: Option<Primitive>,
+
+    #[pdf(other)]
+    pub other: Dictionary,
 }
 
 #[derive(Object, ObjectWrite, Debug, DataSize, Clone)]


### PR DESCRIPTION
When I parsed annotations of pdf, found some missing keys of annot