### PR TITLE
content: emit Op::Shade for the sh operator

### DIFF
--- a/pdf/src/content.rs
+++ b/pdf/src/content.rs
@@ -408,9 +408,7 @@ impl OpBuilder {
             "sc" | "scn" => {
                 push(Op::FillColor { color: Color::Other(args.collect()) });
             }
-            "sh"  => {
-
-            }
+            "sh"  => push(Op::Shade { name: name(&mut args)? }),
             "T*"  => push(Op::TextNewline),
             "Tc"  => push(Op::CharSpacing { char_space: number(&mut args)? }),
             "Td"  => push(Op::MoveTextPosition { translation: point(&mut args)? }),
@@ -1193,5 +1191,15 @@ EI
 "###;
         let mut lexer = Lexer::new(data);
         assert!(inline_image(&mut lexer, &NoResolve).is_ok());
+    }
+
+    #[test]
+    fn test_sh_operator() {
+        // `sh` must emit Op::Shade carrying the shading resource name.
+        let ops = parse_ops(b"/Sh1 sh", &NoResolve).expect("parse sh");
+        assert!(
+            matches!(ops.as_slice(), [Op::Shade { name }] if name.as_str() == "Sh1"),
+            "expected [Op::Shade {{ name: Sh1 }}], got {ops:?}"
+        );
     }
 }


### PR DESCRIPTION
## What

The `sh` operator (paint a shading across the current clip) had an empty
handler in the content-stream parser, so `Op::Shade` was never produced:

```rust
"sh"  => {

}
```

`Op::Shade { name: Name }` and its `ObjectWrite` side already exist — only the
parser was a no-op, so direct shadings were silently dropped for every consumer.

## Fix

```rust
"sh"  => push(Op::Shade { name: name(&mut args)? }),
```

Mirrors the other resource-name operators (`Do`, `gs`, `Tf`, …).

## Test

Adds `content::tests::test_sh_operator`: parsing `/Sh1 sh` now yields
`[Op::Shade { name: "Sh1" }]`.

`cargo test -p pdf` passes (27 unit + 6 integration + 2 xref).
