### PR TITLE
crypt: use the full 32-byte key for AES-256 (AESV3)

### DIFF
--- a/pdf/src/crypt.rs
+++ b/pdf/src/crypt.rs
@@ -154,7 +154,11 @@ impl Decoder {
     }
 
     fn key(&self) -> &[u8] {
-        &self.key[.. std::cmp::min(self.key_size, 16)]
+        // RC4 (V2) and AES-128 (AESV2) use at most a 16-byte key, but AES-256
+        // (AESV3) needs the full 32 bytes — capping at 16 there truncates the
+        // file key and corrupts every stream/string it decrypts.
+        let max = if matches!(self.method, CryptMethod::AESV3) { 32 } else { 16 };
+        &self.key[.. std::cmp::min(self.key_size, max)]
     }
 
     pub fn new(key: Vec<u8>, key_size: usize, method: CryptMethod, encrypt_metadata: bool) -> Decoder {

--- a/pdf/tests/integration.rs
+++ b/pdf/tests/integration.rs
@@ -89,6 +89,33 @@ fn owner_password() {
     }
 }
 
+// Decrypting a *stream* exercises the file key end-to-end. Opening and walking
+// page dictionaries isn't enough — PDF encrypts only strings and streams, not
+// dictionary structure, so a wrong/truncated key still parses dicts fine. This
+// regresses the AES-256 (AESV3) key-truncation bug, which only showed when a
+// stream was actually decrypted (object stream or content stream).
+#[cfg(feature = "cache")]
+#[test]
+fn decrypt_streams() {
+    let mut decoded_any = false;
+    for path in dir_pdfs(file_path("password_protected")) {
+        let path = path.to_str().unwrap();
+        println!("\n == decrypting streams in `{}` ==", path);
+        let file = run!(FileOptions::cached().password(b"userpassword").open(path));
+        let resolver = file.resolver();
+        for i in 0..file.num_pages() {
+            let page = run!(file.get_page(i));
+            if let Some(content) = &page.contents {
+                // Forces decrypt + filter-decode of the content stream; a bad
+                // key yields garbage that fails to inflate/parse here.
+                let ops = run!(content.operations(&resolver));
+                decoded_any |= !ops.is_empty();
+            }
+        }
+    }
+    assert!(decoded_any, "no content stream was decoded — test exercised nothing");
+}
+
 // Test for invalid PDFs found by fuzzing.
 // We don't care if they give an Err or Ok, as long as they don't panic.
 #[cfg(feature = "cache")]


### PR DESCRIPTION
## What

AES-256 (AESV3 / R6) documents fail to decrypt: the password validates, but the
first **stream** that needs decrypting (an object stream holding the catalog, or
any content stream) errors with `DecryptionFailure`.

## Root cause

`Decoder::key()` capped the key length at 16:

```rust
fn key(&self) -> &[u8] {
    &self.key[.. std::cmp::min(self.key_size, 16)]
}
```

That's right for RC4 (V2) and AES-128 (AESV2), but it **truncates the 32-byte
AES-256 file key to 16 bytes**, so `Aes256CbcDec` runs with the wrong key.

It hid because PDF encrypts only **strings and streams**, not dictionary
structure — so dict-only objects (a plain catalog, page nodes) still parse, and
opening + walking pages looks fine. It only breaks once a real stream is
decrypted. (Key *derivation* was correct, which is why the password validated.)

## Fix

```rust
fn key(&self) -> &[u8] {
    let max = if matches!(self.method, CryptMethod::AESV3) { 32 } else { 16 };
    &self.key[.. std::cmp::min(self.key_size, max)]
}
```

## Test

Adds `decrypt_streams`, which decodes a content stream from every file under
`files/password_protected/` (including `passwords_aes_256.pdf` and
`passwords_aes_256_hardened.pdf`). Decoding a stream is what exercises the file
key end to end — the existing `open_file` / `read_pages` / `user_password` tests
only walk dictionaries, so they passed even with the truncated key.

Verified the new test **fails on `master`** and passes with this change. RC4 /
AES-128 unaffected. Full suite green (26 unit + 7 integration + 2 xref).
