### PR TITLE
object: fix case-swapped page-label Counter styles, dedup duplicates

### DIFF
--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -313,40 +313,10 @@ impl DataSize for AppearanceStreamEntry {
     }
 }
 
-#[derive(Debug, DataSize, Clone, Object, ObjectWrite, DeepClone)]
-pub enum Counter {
-    #[pdf(name="D")]
-    Arabic,
-    #[pdf(name="r")]
-    RomanUpper,
-    #[pdf(name="R")]
-    RomanLower,
-    #[pdf(name="a")]
-    AlphaUpper,
-    #[pdf(name="A")]
-    AlphaLower
-}
-
-#[derive(Debug, DataSize)]
-pub enum NameTreeNode<T> {
-    ///
-    Intermediate (Vec<Ref<NameTree<T>>>),
-    ///
-    Leaf (Vec<(PdfString, T)>)
-
-}
-
-#[derive(Object, ObjectWrite, Clone, DeepClone, Debug)]
-pub struct LageLabel {
-    #[pdf(key = "S")]
-    style: Option<Counter>,
-
-    #[pdf(key = "P")]
-    prefix: Option<PdfString>,
-
-    #[pdf(key = "St")]
-    start: Option<i32>,
-}
+// `Counter` and `NameTreeNode` live in the `nametree` submodule (glob-imported
+// above); `PageLabel` lives in the `page` submodule. Earlier copies here
+// duplicated them — the `Counter` one was even case-swapped — so they were
+// removed to keep a single source of truth.
 
 #[derive(Debug, Clone, DeepClone, DataSize)]
 pub enum DestView {

--- a/pdf/src/object/types/nametree.rs
+++ b/pdf/src/object/types/nametree.rs
@@ -2,17 +2,22 @@ use std::collections::VecDeque;
 
 use super::prelude::*;
 
+/// A page-label numbering style (`/S` in a `PageLabel` dictionary).
+///
+/// The `/S` names are case-sensitive per PDF 32000-1 §12.4.2 Table 159:
+/// `R`/`r` are upper/lower-case Roman numerals and `A`/`a` are upper/lower-case
+/// letters respectively.
 #[derive(Debug, DataSize, Clone, Object, ObjectWrite, DeepClone)]
 pub enum Counter {
     #[pdf(name = "D")]
     Arabic,
-    #[pdf(name = "r")]
-    RomanUpper,
     #[pdf(name = "R")]
+    RomanUpper,
+    #[pdf(name = "r")]
     RomanLower,
-    #[pdf(name = "a")]
-    AlphaUpper,
     #[pdf(name = "A")]
+    AlphaUpper,
+    #[pdf(name = "a")]
     AlphaLower,
 }
 
@@ -156,5 +161,27 @@ impl<T> NameTree<T> {
         let mut entries = VecDeque::from(entries);
 
         unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Counter;
+    use crate::object::{NoResolve, Object};
+    use crate::primitive::Primitive;
+
+    fn parse(name: &str) -> Counter {
+        Counter::from_primitive(Primitive::Name(name.into()), &NoResolve).unwrap()
+    }
+
+    // The `/S` page-label style names are case-sensitive (PDF 32000-1 §12.4.2):
+    // `R`/`r` are upper/lower-case Roman, `A`/`a` upper/lower-case letters.
+    #[test]
+    fn counter_style_names_are_case_sensitive() {
+        assert!(matches!(parse("D"), Counter::Arabic));
+        assert!(matches!(parse("R"), Counter::RomanUpper));
+        assert!(matches!(parse("r"), Counter::RomanLower));
+        assert!(matches!(parse("A"), Counter::AlphaUpper));
+        assert!(matches!(parse("a"), Counter::AlphaLower));
     }
 }


### PR DESCRIPTION
The `/S` page-label numbering styles (PDF 32000-1 §12.4.2) are
case-sensitive: `R`/`r` are upper/lower-case Roman numerals and `A`/`a`
are upper/lower-case letters. The `#[pdf(name=…)]` attributes on
`Counter` had these swapped (`name="r"` → `RomanUpper`, etc.), so every
Roman/alpha page label came out in the wrong case.

The same `Counter` enum, plus `NameTreeNode` and a stray typo'd
`LageLabel` (a copy of `PageLabel`), were also duplicated between
`types.rs` and `types/nametree.rs`; the duplicate `Counter` even drew a
dead_code warning. Remove the `types.rs` copies and keep the single
definitions in the `nametree`/`page` submodules (already re-exported via
the `mods!` glob).

Add a regression test that the `/S` names parse to the correct,
case-sensitive variants.
