### PR TITLE
object: inherit /Rotate from ancestor Pages nodes

### DIFF
--- a/pdf/src/build.rs
+++ b/pdf/src/build.rs
@@ -74,7 +74,7 @@ impl PageBuilder {
             crop_box: Some(page.crop_box()?),
             trim_box: page.trim_box,
             resources: (**page.resources()?.data()).clone(),
-            rotate: page.rotate,
+            rotate: page.rotate(),
             metadata: page.metadata.clone(),
             lgi: page.lgi.clone(),
             vp: page.vp.clone(),
@@ -107,7 +107,7 @@ impl PageBuilder {
             crop_box: Some(page.crop_box()?),
             trim_box: page.trim_box,
             resources,
-            rotate: page.rotate,
+            rotate: page.rotate(),
             metadata: page.metadata.deep_clone(cloner)?,
             lgi: page.lgi.deep_clone(cloner)?,
             vp: page.vp.deep_clone(cloner)?,
@@ -151,6 +151,7 @@ impl CatalogBuilder {
                 resources: None,
                 media_box: None,
                 crop_box: None,
+                rotate: None,
             },
             update,
         )?;
@@ -165,7 +166,9 @@ impl CatalogBuilder {
                 crop_box: page.crop_box,
                 trim_box: page.trim_box,
                 resources: Some(resources),
-                rotate: page.rotate,
+                // 0 is the default rotation, so omit `/Rotate` rather than
+                // writing a redundant entry.
+                rotate: (page.rotate != 0).then_some(page.rotate),
                 metadata: page.metadata,
                 lgi: page.lgi,
                 vp: page.vp,

--- a/pdf/src/object/types/page.rs
+++ b/pdf/src/object/types/page.rs
@@ -117,8 +117,11 @@ pub struct Page {
     #[pdf(key = "Contents")]
     pub contents: Option<Content>,
 
-    #[pdf(key = "Rotate", default = "0")]
-    pub rotate: i32,
+    /// Number of degrees (a multiple of 90) the page is rotated clockwise when
+    /// displayed. Inheritable, so prefer the `rotate()` accessor — this is
+    /// `None` when the value must come from an ancestor `Pages` node.
+    #[pdf(key = "Rotate")]
+    pub rotate: Option<i32>,
 
     #[pdf(key = "Metadata")]
     pub metadata: Option<Primitive>,
@@ -203,7 +206,7 @@ impl Page {
             trim_box: None,
             resources: None,
             contents: None,
-            rotate: 0,
+            rotate: None,
             metadata: None,
             lgi: None,
             vp: None,
@@ -242,6 +245,14 @@ impl Page {
                 }
             }),
         }
+    }
+    /// The page rotation in degrees clockwise (a multiple of 90). `/Rotate` is
+    /// inheritable, so this falls back to the nearest ancestor `Pages` node and
+    /// finally to `0` when nothing specifies it.
+    pub fn rotate(&self) -> i32 {
+        self.rotate
+            .or_else(|| inherit(&self.parent, |pt| pt.rotate).ok().flatten())
+            .unwrap_or(0)
     }
 }
 impl SubType<PagesNode> for Page {}

--- a/pdf/src/object/types/pagesnode.rs
+++ b/pdf/src/object/types/pagesnode.rs
@@ -50,6 +50,9 @@ pub struct PageTree {
 
     #[pdf(key = "CropBox")]
     pub crop_box: Option<Rectangle>,
+
+    #[pdf(key = "Rotate")]
+    pub rotate: Option<i32>,
 }
 impl PageTree {
     pub fn page(&self, resolve: &impl Resolve, page_nr: u32) -> Result<PageRc> {

--- a/pdf/tests/integration.rs
+++ b/pdf/tests/integration.rs
@@ -116,6 +116,43 @@ fn decrypt_streams() {
     assert!(decoded_any, "no content stream was decoded — test exercised nothing");
 }
 
+// `/Rotate` is an inheritable page attribute: a Page with no `/Rotate` of its
+// own takes the value from the nearest ancestor `Pages` node. This builds a
+// minimal one-page document whose rotation lives only on the page tree and
+// asserts the page reports it.
+#[cfg(feature = "cache")]
+#[test]
+fn rotate_is_inherited() {
+    let objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 612 792] /Rotate 90 >>",
+        "<< /Type /Page /Parent 2 0 R >>",
+    ];
+    let mut pdf = String::from("%PDF-1.5\n");
+    let mut offsets = Vec::new();
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.push_str(&format!("{} 0 obj {} endobj\n", i + 1, body));
+    }
+    let startxref = pdf.len();
+    // Classic cross-reference table; each entry line is exactly 20 bytes.
+    pdf.push_str(&format!("xref\n0 {}\n", objects.len() + 1));
+    pdf.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.push_str(&format!("{off:010} 00000 n \n"));
+    }
+    pdf.push_str(&format!(
+        "trailer << /Root 1 0 R /Size {} >>\nstartxref\n{}\n%%EOF",
+        objects.len() + 1,
+        startxref
+    ));
+
+    let file = run!(FileOptions::cached().load(pdf.into_bytes()));
+    let page = run!(file.get_page(0));
+    assert!(page.rotate.is_none(), "the page itself must not carry /Rotate");
+    assert_eq!(page.rotate(), 90, "page should inherit /Rotate from its parent Pages node");
+}
+
 // Test for invalid PDFs found by fuzzing.
 // We don't care if they give an Err or Ok, as long as they don't panic.
 #[cfg(feature = "cache")]


### PR DESCRIPTION
`/Rotate` is an inheritable page attribute, but `Page.rotate` defaulted
to 0 and never walked the page tree, so pages relying on a rotation set
on an ancestor `Pages` node rendered unrotated.

Make `Page.rotate` an `Option<i32>`, add a `rotate` field to `PageTree`,
and add `Page::rotate()` that resolves the effective rotation by
inheriting up the `Pages` chain (mirroring `media_box()`/`crop_box()`),
defaulting to 0. Update the build/clone paths accordingly: writers omit
`/Rotate` when it is 0.

Add an integration test that builds a one-page document whose rotation
lives only on the page tree and asserts the page inherits it.
