### PR TITLE
object: parse annotation /AP appearance entries given as references

### DIFF
--- a/examples/src/bin/action.rs
+++ b/examples/src/bin/action.rs
@@ -149,7 +149,7 @@ fn main() -> Result<(), PdfError> {
         })?;
 
         let button_as = AppearanceStreams {
-            normal: file.create(AppearanceStreamEntry::Single(xo.into()))?.into(),
+            normal: AppearanceStreamEntry::Single(xo.into()),
             down: None,
             rollover: None
         };
@@ -211,7 +211,7 @@ fn main() -> Result<(), PdfError> {
 
         // AP
         annot.appearance_streams = Some(file.create(AppearanceStreams {
-            normal: AppearanceStreamEntry::Single(fxo.clone().into()).into(),
+            normal: AppearanceStreamEntry::Single(fxo.clone().into()),
             down: None,
             rollover: None
         })?.into());

--- a/pdf/src/object/types.rs
+++ b/pdf/src/object/types.rs
@@ -287,10 +287,35 @@ pub enum AppearanceStreamEntry {
 }
 impl Object for AppearanceStreamEntry {
     fn from_primitive(p: Primitive, resolve: &impl Resolve) -> Result<Self> {
-        match p.resolve(resolve)? {
-            p @ Primitive::Dictionary(_) => Object::from_primitive(p, resolve).map(AppearanceStreamEntry::Dict),
-            p @ Primitive::Stream(_) => Object::from_primitive(p, resolve).map(AppearanceStreamEntry::Single),
-            p => Err(PdfError::UnexpectedPrimitive {expected: "Dict or Stream", found: p.get_debug_name()})
+        // An appearance entry (`/N`, `/R`, `/D`) is either a single form
+        // XObject — the overwhelmingly common case — or a sub-dictionary mapping
+        // appearance-state names (e.g. `/On`, `/Off`) to such forms, used by
+        // check boxes and radio buttons.
+        //
+        // A stream is always an indirect object and `Single` holds an
+        // `RcRef<FormXObject>`, so the reference must be carried through: peek at
+        // what it resolves to, but build the `RcRef` from the original reference.
+        // Resolving the reference to a `Stream` *before* dispatching (as this
+        // used to) made the `Single` arm fail with "expected Reference, found
+        // Stream", which broke the typed API for nearly every annotation.
+        match p {
+            Primitive::Reference(r) => match resolve.resolve(r)? {
+                Primitive::Stream(_) => resolve.get(Ref::new(r)).map(AppearanceStreamEntry::Single),
+                dict @ Primitive::Dictionary(_) => {
+                    Object::from_primitive(dict, resolve).map(AppearanceStreamEntry::Dict)
+                }
+                other => Err(PdfError::UnexpectedPrimitive {
+                    expected: "Stream or Dictionary",
+                    found: other.get_debug_name(),
+                }),
+            },
+            p @ Primitive::Dictionary(_) => {
+                Object::from_primitive(p, resolve).map(AppearanceStreamEntry::Dict)
+            }
+            p => Err(PdfError::UnexpectedPrimitive {
+                expected: "Reference or Dictionary",
+                found: p.get_debug_name(),
+            }),
         }
     }
 }

--- a/pdf/src/object/types/form.rs
+++ b/pdf/src/object/types/form.rs
@@ -360,13 +360,13 @@ impl FieldDictionary {
 #[derive(Object, ObjectWrite, Debug, DataSize, Clone, DeepClone)]
 pub struct AppearanceStreams {
     #[pdf(key = "N")]
-    pub normal: MaybeRef<AppearanceStreamEntry>,
+    pub normal: AppearanceStreamEntry,
 
     #[pdf(key = "R")]
-    pub rollover: Option<MaybeRef<AppearanceStreamEntry>>,
+    pub rollover: Option<AppearanceStreamEntry>,
 
     #[pdf(key = "D")]
-    pub down: Option<MaybeRef<AppearanceStreamEntry>>,
+    pub down: Option<AppearanceStreamEntry>,
 }
 
 #[derive(Object, ObjectWrite, Debug, DataSize, Clone, Default)]

--- a/pdf/tests/integration.rs
+++ b/pdf/tests/integration.rs
@@ -116,6 +116,58 @@ fn decrypt_streams() {
     assert!(decoded_any, "no content stream was decoded — test exercised nothing");
 }
 
+// The typed annotation API must accept the ubiquitous appearance form
+//   /AP << /N 5 0 R >>
+// where `/N` references a form-XObject stream. Because a stream is always an
+// indirect object, this is how essentially every annotation appearance is
+// written; it previously failed with "expected Reference, found Stream".
+#[cfg(feature = "cache")]
+#[test]
+fn appearance_stream_n_reference_parses() {
+    let form = "q Q"; // a minimal (no-op) form XObject content stream
+    let objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 612 792] >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /Annots [4 0 R] >>".to_string(),
+        "<< /Type /Annot /Subtype /Widget /Rect [0 0 100 50] /AP << /N 5 0 R >> >>".to_string(),
+        format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 100 50] /Length {} >>\nstream\n{}\nendstream",
+            form.len(),
+            form
+        ),
+    ];
+    let mut pdf = String::from("%PDF-1.5\n");
+    let mut offsets = Vec::new();
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.push_str(&format!("{} 0 obj {} endobj\n", i + 1, body));
+    }
+    let startxref = pdf.len();
+    pdf.push_str(&format!("xref\n0 {}\n", objects.len() + 1));
+    pdf.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.push_str(&format!("{off:010} 00000 n \n"));
+    }
+    pdf.push_str(&format!(
+        "trailer << /Root 1 0 R /Size {} >>\nstartxref\n{}\n%%EOF",
+        objects.len() + 1,
+        startxref
+    ));
+
+    let file = run!(FileOptions::cached().load(pdf.into_bytes()));
+    let resolver = file.resolver();
+    let page = run!(file.get_page(0));
+    let annots = run!(page.annotations.load(&resolver));
+    let annots: &Vec<MaybeRef<Annot>> = &annots;
+    assert_eq!(annots.len(), 1, "the page should have one annotation");
+    let annot: &Annot = &annots[0];
+    let ap = annot.appearance_streams.as_ref().expect("annotation has an /AP");
+    assert!(
+        matches!(ap.normal, AppearanceStreamEntry::Single(_)),
+        "the /N reference-to-stream should parse as a single form XObject"
+    );
+}
+
 // Test for invalid PDFs found by fuzzing.
 // We don't care if they give an Err or Ok, as long as they don't panic.
 #[cfg(feature = "cache")]


### PR DESCRIPTION
`/AP` in the usual `/N <ref>` form didn't parse — "expected Reference, found Stream". The field was `MaybeRef<AppearanceStreamEntry>`, so the ref got resolved before `AppearanceStreamEntry::from_primitive` ever saw it, but the `Single` arm needs the reference itself (it holds `RcRef<FormXObject>`, and streams are always indirect objects). So it broke on basically every annotation appearance.

Dropped the `MaybeRef` wrapper on `normal`/`rollover`/`down` and let the entry keep the reference: peek at what it resolves to, then build the `RcRef` from the original ref (write path still round-trips), or parse the state subdictionary for the checkbox/radio case.

Integration test loads an annotation whose `/N` references a form stream.
