### PR TITLE
font: model Type 3 fonts instead of dropping them into Other

### DIFF
--- a/pdf/src/font.rs
+++ b/pdf/src/font.rs
@@ -1,4 +1,5 @@
 use crate as pdf;
+use crate::content::Matrix;
 use crate::encoding::Encoding;
 use crate::error::*;
 use crate::object::*;
@@ -76,6 +77,7 @@ pub enum FontData {
     TrueType(TFont),
     CIDFontType0(CIDFont),
     CIDFontType2(CIDFont),
+    Type3(Type3Font),
     Other(Dictionary),
 }
 
@@ -160,6 +162,7 @@ impl Object for Font {
             FontType::TrueType => FontData::TrueType(TFont::from_dict(dict, resolve)?),
             FontType::CIDFontType0 => FontData::CIDFontType0(CIDFont::from_dict(dict, resolve)?),
             FontType::CIDFontType2 => FontData::CIDFontType2(CIDFont::from_dict(dict, resolve)?),
+            FontType::Type3 => FontData::Type3(Type3Font::from_dict(dict, resolve)?),
             _ => FontData::Other(dict),
         };
 
@@ -179,6 +182,7 @@ impl ObjectWrite for Font {
             FontData::CIDFontType0(ref d) | FontData::CIDFontType2(ref d) => d.to_dict(update)?,
             FontData::TrueType(ref d) | FontData::Type1(ref d) => d.to_dict(update)?,
             FontData::Type0(ref d) => d.to_dict(update)?,
+            FontData::Type3(ref d) => d.to_dict(update)?,
             FontData::Other(ref dict) => dict.clone(),
         };
 
@@ -198,6 +202,7 @@ impl ObjectWrite for Font {
             FontData::TrueType(_) => FontType::TrueType,
             FontData::CIDFontType0(_) => FontType::CIDFontType0,
             FontData::CIDFontType2(_) => FontType::CIDFontType2,
+            FontData::Type3(_) => FontType::Type3,
             FontData::Other(_) => bail!("unimplemented"),
         };
         dict.insert("Subtype", subtype.to_primitive(update)?);
@@ -322,6 +327,13 @@ impl Font {
             _ => None,
         }
     }
+    /// The typed Type 3 font data, if this is a Type 3 font.
+    pub fn type3(&self) -> Option<&Type3Font> {
+        match self.data {
+            FontData::Type3(ref t3) => Some(t3),
+            _ => None,
+        }
+    }
     pub fn widths(&self, resolve: &impl Resolve) -> Result<Option<Widths>> {
         match self.data {
             FontData::Type0(ref t0) => t0.descendant_fonts[0].widths(resolve),
@@ -434,6 +446,43 @@ pub struct CIDFont {
 
     #[pdf(other)]
     pub _other: Dictionary,
+}
+
+/// A Type 3 font (PDF 32000-1 §9.6.5), whose glyphs are defined by content
+/// streams rather than a font program. The glyph procedures in `char_procs`
+/// run in the font's own `font_matrix` glyph space, using `resources`.
+#[derive(Object, ObjectWrite, Debug, DataSize, DeepClone)]
+pub struct Type3Font {
+    /// Maps glyph space to text space (required).
+    #[pdf(key = "FontMatrix")]
+    pub font_matrix: Matrix,
+
+    /// Glyph name → the content stream that paints that glyph (required).
+    #[pdf(key = "CharProcs")]
+    pub char_procs: HashMap<Name, RcRef<Stream<()>>>,
+
+    /// Resources used by the glyph procedures.
+    #[pdf(key = "Resources")]
+    pub resources: Option<MaybeRef<Resources>>,
+
+    #[pdf(key = "FontBBox")]
+    pub font_bbox: Option<Rectangle>,
+
+    /// per spec required, but some files lack it.
+    #[pdf(key = "FirstChar")]
+    pub first_char: Option<i32>,
+
+    /// same
+    #[pdf(key = "LastChar")]
+    pub last_char: Option<i32>,
+
+    /// Glyph widths in glyph space (scaled by `font_matrix`), indexed from
+    /// `first_char`.
+    #[pdf(key = "Widths")]
+    pub widths: Option<Vec<f32>>,
+
+    #[pdf(key = "FontDescriptor")]
+    pub font_descriptor: Option<FontDescriptor>,
 }
 
 #[derive(Object, ObjectWrite, Debug, DataSize, DeepClone)]

--- a/pdf/tests/integration.rs
+++ b/pdf/tests/integration.rs
@@ -116,6 +116,53 @@ fn decrypt_streams() {
     assert!(decoded_any, "no content stream was decoded — test exercised nothing");
 }
 
+// A Type 3 font should parse into the typed `Type3Font` (font matrix, glyph
+// procedures, widths) rather than being dumped into `FontData::Other`.
+#[cfg(feature = "cache")]
+#[test]
+fn type3_font_parses() {
+    let glyph = "1000 0 0 0 750 750 d1"; // a Type 3 glyph procedure
+    let objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 612 792] >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R >>".to_string(),
+        "<< /Type /Font /Subtype /Type3 /FontMatrix [0.001 0 0 0.001 0 0] \
+         /FontBBox [0 0 750 750] /CharProcs 5 0 R \
+         /Encoding << /Type /Encoding /Differences [65 /a] >> \
+         /FirstChar 65 /LastChar 65 /Widths [600] >>"
+            .to_string(),
+        "<< /a 6 0 R >>".to_string(),
+        format!("<< /Length {} >>\nstream\n{}\nendstream", glyph.len(), glyph),
+    ];
+    let mut pdf = String::from("%PDF-1.5\n");
+    let mut offsets = Vec::new();
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.push_str(&format!("{} 0 obj {} endobj\n", i + 1, body));
+    }
+    let startxref = pdf.len();
+    pdf.push_str(&format!("xref\n0 {}\n", objects.len() + 1));
+    pdf.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        pdf.push_str(&format!("{off:010} 00000 n \n"));
+    }
+    pdf.push_str(&format!(
+        "trailer << /Root 1 0 R /Size {} >>\nstartxref\n{}\n%%EOF",
+        objects.len() + 1,
+        startxref
+    ));
+
+    let file = run!(FileOptions::cached().load(pdf.into_bytes()));
+    let resolver = file.resolver();
+    let font: RcRef<pdf::font::Font> = run!(resolver.get(Ref::new(PlainRef { id: 4, gen: 0 })));
+    let t3 = font.type3().expect("the font should parse as a typed Type 3 font");
+    // Parsing CharProcs as RcRef<Stream<()>> proves the glyph stream resolved.
+    assert_eq!(t3.char_procs.len(), 1, "one glyph procedure");
+    assert_eq!(t3.first_char, Some(65));
+    assert_eq!(t3.widths.as_deref(), Some([600.0].as_slice()));
+    assert!((t3.font_matrix.a - 0.001).abs() < 1e-6, "font matrix preserved");
+}
+
 // Test for invalid PDFs found by fuzzing.
 // We don't care if they give an Err or Ok, as long as they don't panic.
 #[cfg(feature = "cache")]


### PR DESCRIPTION
Type 3 fonts landed in `FontData::Other(dict)`, so anyone using them had to dig `FontMatrix`, `CharProcs`, `Widths` and friends out of the raw dictionary themselves.

Adds a typed `Type3Font` (matrix, glyph procs as `HashMap<Name, RcRef<Stream<()>>>`, resources, bbox, char range + widths, descriptor), a `FontData::Type3` variant wired through parse and serialize, and a `Font::type3()` accessor. Only `FontMatrix`/`CharProcs` are treated as required, and the whole dict still lives in `Font._other`, so nothing that loaded before regresses.

Test checks the matrix, procs and widths come through typed.
