### PR TITLE
font: make FontDescriptor /FontBBox optional

### DIFF
--- a/pdf/src/font.rs
+++ b/pdf/src/font.rs
@@ -450,13 +450,16 @@ pub struct FontDescriptor {
     #[pdf(key = "FontWeight")]
     pub font_weight: Option<f32>,
 
-    #[pdf(key = "Flags")]
+    #[pdf(key = "Flags", default = "0")]
     pub flags: u32,
 
+    // Required per spec, but omitted by many real-world fonts (esp. subset/CID
+    // descendants). It's metadata we don't render from, so treat it as optional
+    // rather than failing the whole font — and with it all the font's text.
     #[pdf(key = "FontBBox")]
-    pub font_bbox: Rectangle,
+    pub font_bbox: Option<Rectangle>,
 
-    #[pdf(key = "ItalicAngle")]
+    #[pdf(key = "ItalicAngle", default = "0.")]
     pub italic_angle: f32,
 
     // required as per spec, but still missing in some cases


### PR DESCRIPTION
Subsetted and CID-descendant fonts often leave out `/FontBBox`. Because `font_bbox` was required, the missing entry failed `FontDescriptor` parsing, which bubbled up through `Option<FontDescriptor>` and made the whole `Font` fail to load — so every glyph from that font silently disappeared.

Nothing actually reads `font_bbox` (outlines come from the embedded program), so I've made it optional and defaulted `Flags`/`ItalicAngle` for the same reason. Ran into this on a PDF where roughly two-thirds of the pages were quietly dropping text from secondary fonts.
